### PR TITLE
Add RISC-V support for more packages

### DIFF
--- a/binaries/40four/static.official.source.yaml
+++ b/binaries/40four/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/40four/static.official.source.yaml
+++ b/binaries/40four/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/afrog/static.official.source.yaml
+++ b/binaries/afrog/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/afrog/static.official.source.yaml
+++ b/binaries/afrog/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/age/static.official.source.yaml
+++ b/binaries/age/static.official.source.yaml
@@ -71,7 +71,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/age/static.official.source.yaml
+++ b/binaries/age/static.official.source.yaml
@@ -51,6 +51,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -70,7 +71,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/airixss/static.official.source.yaml
+++ b/binaries/airixss/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/airixss/static.official.source.yaml
+++ b/binaries/airixss/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aliyun-cli/static.official.source.yaml
+++ b/binaries/aliyun-cli/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aliyun-cli/static.official.source.yaml
+++ b/binaries/aliyun-cli/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux" 
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/allxfr/static.official.source.yaml
+++ b/binaries/allxfr/static.official.source.yaml
@@ -30,6 +30,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -49,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/allxfr/static.official.source.yaml
+++ b/binaries/allxfr/static.official.source.yaml
@@ -50,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/alpine/static.official.stable.yaml
+++ b/binaries/alpine/static.official.stable.yaml
@@ -31,6 +31,7 @@ tag:
 x_exec:
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |

--- a/binaries/amass/static.official.source.yaml
+++ b/binaries/amass/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/amass/static.official.source.yaml
+++ b/binaries/amass/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux" 
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/analyticsrelationships/static.official.source.yaml
+++ b/binaries/analyticsrelationships/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/analyticsrelationships/static.official.source.yaml
+++ b/binaries/analyticsrelationships/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/anew/static.official.source.yaml
+++ b/binaries/anew/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/anew/static.official.source.yaml
+++ b/binaries/anew/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/anyproxy/static.official.source.yaml
+++ b/binaries/anyproxy/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/anyproxy/static.official.source.yaml
+++ b/binaries/anyproxy/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aptly/static.official.source.yaml
+++ b/binaries/aptly/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aptly/static.official.source.yaml
+++ b/binaries/aptly/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/apx/static.official.source.yaml
+++ b/binaries/apx/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/apx/static.official.source.yaml
+++ b/binaries/apx/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/arc-archiver/static.official.source.yaml
+++ b/binaries/arc-archiver/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/arc-archiver/static.official.source.yaml
+++ b/binaries/arc-archiver/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/archive-finder/static.official.source.yaml
+++ b/binaries/archive-finder/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/archive-finder/static.official.source.yaml
+++ b/binaries/archive-finder/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aretext/static.official.source.yaml
+++ b/binaries/aretext/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aretext/static.official.source.yaml
+++ b/binaries/aretext/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/asnmap/static.official.source.yaml
+++ b/binaries/asnmap/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/asnmap/static.official.source.yaml
+++ b/binaries/asnmap/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/assetfinder/static.official.source.yaml
+++ b/binaries/assetfinder/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/assetfinder/static.official.source.yaml
+++ b/binaries/assetfinder/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/assh/static.official.source.yaml
+++ b/binaries/assh/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/assh/static.official.source.yaml
+++ b/binaries/assh/static.official.source.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aterm/static.official.source.yaml
+++ b/binaries/aterm/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/aterm/static.official.source.yaml
+++ b/binaries/aterm/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/axfr2hosts/static.official.source.yaml
+++ b/binaries/axfr2hosts/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/axfr2hosts/static.official.source.yaml
+++ b/binaries/axfr2hosts/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/backtrace/static.official.source.yaml
+++ b/binaries/backtrace/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/backtrace/static.official.source.yaml
+++ b/binaries/backtrace/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bearer/static.official.source.yaml
+++ b/binaries/bearer/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bearer/static.official.source.yaml
+++ b/binaries/bearer/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bed/static.official.source.yaml
+++ b/binaries/bed/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bed/static.official.source.yaml
+++ b/binaries/bed/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/berty/static.official.source.yaml
+++ b/binaries/berty/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/berty/static.official.source.yaml
+++ b/binaries/berty/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bleve/static.official.source.yaml
+++ b/binaries/bleve/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bleve/static.official.source.yaml
+++ b/binaries/bleve/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bombadillo/static.official.source.yaml
+++ b/binaries/bombadillo/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bombadillo/static.official.source.yaml
+++ b/binaries/bombadillo/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/botsay/static.official.source.yaml
+++ b/binaries/botsay/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/botsay/static.official.source.yaml
+++ b/binaries/botsay/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/brutespray/static.official.source.yaml
+++ b/binaries/brutespray/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/brutespray/static.official.source.yaml
+++ b/binaries/brutespray/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bucketloot/static.official.source.yaml
+++ b/binaries/bucketloot/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bucketloot/static.official.source.yaml
+++ b/binaries/bucketloot/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bunster/static.official.source.yaml
+++ b/binaries/bunster/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/bunster/static.official.source.yaml
+++ b/binaries/bunster/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/byp4xx/static.official.source.yaml
+++ b/binaries/byp4xx/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/byp4xx/static.official.source.yaml
+++ b/binaries/byp4xx/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cariddi/static.official.source.yaml
+++ b/binaries/cariddi/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cariddi/static.official.source.yaml
+++ b/binaries/cariddi/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/catcher/static.official.source.yaml
+++ b/binaries/catcher/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/catcher/static.official.source.yaml
+++ b/binaries/catcher/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cert-cli/static.official.source.yaml
+++ b/binaries/cert-cli/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cert-cli/static.official.source.yaml
+++ b/binaries/cert-cli/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certgraph/static.official.source.yaml
+++ b/binaries/certgraph/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certgraph/static.official.source.yaml
+++ b/binaries/certgraph/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certinfo/static.official.source.yaml
+++ b/binaries/certinfo/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certinfo/static.official.source.yaml
+++ b/binaries/certinfo/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certspotter/static.official.source.yaml
+++ b/binaries/certspotter/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certspotter/static.official.source.yaml
+++ b/binaries/certspotter/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certstream-server/static.official.source.yaml
+++ b/binaries/certstream-server/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/certstream-server/static.official.source.yaml
+++ b/binaries/certstream-server/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cfspeed/static.official.source.yaml
+++ b/binaries/cfspeed/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cfspeed/static.official.source.yaml
+++ b/binaries/cfspeed/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cftun/static.official.source.yaml
+++ b/binaries/cftun/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cftun/static.official.source.yaml
+++ b/binaries/cftun/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cheat/static.official.source.yaml
+++ b/binaries/cheat/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cheat/static.official.source.yaml
+++ b/binaries/cheat/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/checkcdn/static.official.source.yaml
+++ b/binaries/checkcdn/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/checkcdn/static.official.source.yaml
+++ b/binaries/checkcdn/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/chisel/static.official.source.yaml
+++ b/binaries/chisel/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/chisel/static.official.source.yaml
+++ b/binaries/chisel/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/chromedb/static.official.source.yaml
+++ b/binaries/chromedb/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/chromedb/static.official.source.yaml
+++ b/binaries/chromedb/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cleed/static.official.source.yaml
+++ b/binaries/cleed/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cleed/static.official.source.yaml
+++ b/binaries/cleed/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cli53/static.official.source.yaml
+++ b/binaries/cli53/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cli53/static.official.source.yaml
+++ b/binaries/cli53/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/clive/static.official.source.yaml
+++ b/binaries/clive/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/clive/static.official.source.yaml
+++ b/binaries/clive/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cloudflare-warp-speedtest/static.official.source.yaml
+++ b/binaries/cloudflare-warp-speedtest/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cloudflare-warp-speedtest/static.official.source.yaml
+++ b/binaries/cloudflare-warp-speedtest/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cloudfox/static.official.source.yaml
+++ b/binaries/cloudfox/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cloudfox/static.official.source.yaml
+++ b/binaries/cloudfox/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cloudsword/static.official.source.yaml
+++ b/binaries/cloudsword/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cloudsword/static.official.source.yaml
+++ b/binaries/cloudsword/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cobalt-cli/static.official.source.yaml
+++ b/binaries/cobalt-cli/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cobalt-cli/static.official.source.yaml
+++ b/binaries/cobalt-cli/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/codesearch/static.official.source.yaml
+++ b/binaries/codesearch/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/codesearch/static.official.source.yaml
+++ b/binaries/codesearch/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/comb/static.official.source.yaml
+++ b/binaries/comb/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/comb/static.official.source.yaml
+++ b/binaries/comb/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/compiledb-go/static.official.source.yaml
+++ b/binaries/compiledb-go/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/compiledb-go/static.official.source.yaml
+++ b/binaries/compiledb-go/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/container2wasm/static.official.source.yaml
+++ b/binaries/container2wasm/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/container2wasm/static.official.source.yaml
+++ b/binaries/container2wasm/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cookiemonster/static.official.source.yaml
+++ b/binaries/cookiemonster/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cookiemonster/static.official.source.yaml
+++ b/binaries/cookiemonster/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cowitness/static.official.source.yaml
+++ b/binaries/cowitness/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cowitness/static.official.source.yaml
+++ b/binaries/cowitness/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cowsay/static.official.source.yaml
+++ b/binaries/cowsay/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cowsay/static.official.source.yaml
+++ b/binaries/cowsay/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cpu/static.official.source.yaml
+++ b/binaries/cpu/static.official.source.yaml
@@ -44,6 +44,7 @@ x_exec:
   bsys: "docker://rust+go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -81,7 +82,7 @@ x_exec:
          -C link-arg=-Wl,--build-id=none"
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS RUSTFLAGS
       #Build

--- a/binaries/cpu/static.official.source.yaml
+++ b/binaries/cpu/static.official.source.yaml
@@ -82,7 +82,7 @@ x_exec:
          -C link-arg=-Wl,--build-id=none"
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS RUSTFLAGS
       #Build

--- a/binaries/crane/static.official.source.yaml
+++ b/binaries/crane/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crane/static.official.source.yaml
+++ b/binaries/crane/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crlfuzz/static.official.source.yaml
+++ b/binaries/crlfuzz/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crlfuzz/static.official.source.yaml
+++ b/binaries/crlfuzz/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/croc/static.official.source.yaml
+++ b/binaries/croc/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/croc/static.official.source.yaml
+++ b/binaries/croc/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crt/static.official.source.yaml
+++ b/binaries/crt/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crt/static.official.source.yaml
+++ b/binaries/crt/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crt/static.pkgforge-security.source.yaml
+++ b/binaries/crt/static.pkgforge-security.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crt/static.pkgforge-security.source.yaml
+++ b/binaries/crt/static.pkgforge-security.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crtsher/static.official.source.yaml
+++ b/binaries/crtsher/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/crtsher/static.official.source.yaml
+++ b/binaries/crtsher/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/csprecon/static.official.source.yaml
+++ b/binaries/csprecon/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/csprecon/static.official.source.yaml
+++ b/binaries/csprecon/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/csvtk/static.official.source.yaml
+++ b/binaries/csvtk/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/csvtk/static.official.source.yaml
+++ b/binaries/csvtk/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ct_monitor/static.official.source.yaml
+++ b/binaries/ct_monitor/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ct_monitor/static.official.source.yaml
+++ b/binaries/ct_monitor/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ctrsploit/static.official.source.yaml
+++ b/binaries/ctrsploit/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ctrsploit/static.official.source.yaml
+++ b/binaries/ctrsploit/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/curlie/static.official.source.yaml
+++ b/binaries/curlie/static.official.source.yaml
@@ -64,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/curlie/static.official.source.yaml
+++ b/binaries/curlie/static.official.source.yaml
@@ -44,6 +44,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -63,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cut-cdn/static.official.source.yaml
+++ b/binaries/cut-cdn/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cut-cdn/static.official.source.yaml
+++ b/binaries/cut-cdn/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cutlines/static.official.source.yaml
+++ b/binaries/cutlines/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cutlines/static.official.source.yaml
+++ b/binaries/cutlines/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cvemap/static.official.source.yaml
+++ b/binaries/cvemap/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/cvemap/static.official.source.yaml
+++ b/binaries/cvemap/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dalfox/static.official.source.yaml
+++ b/binaries/dalfox/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dalfox/static.official.source.yaml
+++ b/binaries/dalfox/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dasel/static.official.source.yaml
+++ b/binaries/dasel/static.official.source.yaml
@@ -49,6 +49,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -68,7 +69,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dasel/static.official.source.yaml
+++ b/binaries/dasel/static.official.source.yaml
@@ -69,7 +69,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/datadash/static.official.source.yaml
+++ b/binaries/datadash/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/datadash/static.official.source.yaml
+++ b/binaries/datadash/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/daytona/static.official.source.yaml
+++ b/binaries/daytona/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/daytona/static.official.source.yaml
+++ b/binaries/daytona/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dbbench/static.official.source.yaml
+++ b/binaries/dbbench/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dbbench/static.official.source.yaml
+++ b/binaries/dbbench/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dbin/static.official.source.yaml
+++ b/binaries/dbin/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dbin/static.official.source.yaml
+++ b/binaries/dbin/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dblab/static.official.source.yaml
+++ b/binaries/dblab/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dblab/static.official.source.yaml
+++ b/binaries/dblab/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ddns-go/static.official.source.yaml
+++ b/binaries/ddns-go/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ddns-go/static.official.source.yaml
+++ b/binaries/ddns-go/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/depsdev/static.official.source.yaml
+++ b/binaries/depsdev/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/depsdev/static.official.source.yaml
+++ b/binaries/depsdev/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/desync/static.official.source.yaml
+++ b/binaries/desync/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/desync/static.official.source.yaml
+++ b/binaries/desync/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/diffoci/static.official.source.yaml
+++ b/binaries/diffoci/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/diffoci/static.official.source.yaml
+++ b/binaries/diffoci/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dish/static.official.source.yaml
+++ b/binaries/dish/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dish/static.official.source.yaml
+++ b/binaries/dish/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dive/static.official.source.yaml
+++ b/binaries/dive/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dive/static.official.source.yaml
+++ b/binaries/dive/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dlevel/static.official.source.yaml
+++ b/binaries/dlevel/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dlevel/static.official.source.yaml
+++ b/binaries/dlevel/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dns-doctor/static.official.source.yaml
+++ b/binaries/dns-doctor/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dns-doctor/static.official.source.yaml
+++ b/binaries/dns-doctor/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnscrypt-proxy/static.official.source.yaml
+++ b/binaries/dnscrypt-proxy/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnscrypt-proxy/static.official.source.yaml
+++ b/binaries/dnscrypt-proxy/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnslookup/static.official.source.yaml
+++ b/binaries/dnslookup/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnslookup/static.official.source.yaml
+++ b/binaries/dnslookup/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnspyre/static.official.source.yaml
+++ b/binaries/dnspyre/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnspyre/static.official.source.yaml
+++ b/binaries/dnspyre/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnstake/static.official.source.yaml
+++ b/binaries/dnstake/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnstake/static.official.source.yaml
+++ b/binaries/dnstake/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnsx/static.official.source.yaml
+++ b/binaries/dnsx/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dnsx/static.official.source.yaml
+++ b/binaries/dnsx/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/docker-bench/static.official.source.yaml
+++ b/binaries/docker-bench/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/docker-bench/static.official.source.yaml
+++ b/binaries/docker-bench/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/doggo/static.official.source.yaml
+++ b/binaries/doggo/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/doggo/static.official.source.yaml
+++ b/binaries/doggo/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dperf/static.official.source.yaml
+++ b/binaries/dperf/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dperf/static.official.source.yaml
+++ b/binaries/dperf/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dsieve/static.official.source.yaml
+++ b/binaries/dsieve/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dsieve/static.official.source.yaml
+++ b/binaries/dsieve/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/duf/static.official.source.yaml
+++ b/binaries/duf/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/duf/static.official.source.yaml
+++ b/binaries/duf/static.official.source.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/durl/static.official.source.yaml
+++ b/binaries/durl/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/durl/static.official.source.yaml
+++ b/binaries/durl/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dyff/static.official.source.yaml
+++ b/binaries/dyff/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dyff/static.official.source.yaml
+++ b/binaries/dyff/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dynamic-file-searcher/static.official.source.yaml
+++ b/binaries/dynamic-file-searcher/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/dynamic-file-searcher/static.official.source.yaml
+++ b/binaries/dynamic-file-searcher/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ebpf-hide-pid/static.official.source.yaml
+++ b/binaries/ebpf-hide-pid/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/Acceis/eBPF-hide-PID/blob/main/Makefile

--- a/binaries/ebpf-hide-pid/static.official.source.yaml
+++ b/binaries/ebpf-hide-pid/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/Acceis/eBPF-hide-PID/blob/main/Makefile

--- a/binaries/ecoji/static.official.source.yaml
+++ b/binaries/ecoji/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ecoji/static.official.source.yaml
+++ b/binaries/ecoji/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/eget/static.official.source.yaml
+++ b/binaries/eget/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/eget/static.official.source.yaml
+++ b/binaries/eget/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ehole/static.official.source.yaml
+++ b/binaries/ehole/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ehole/static.official.source.yaml
+++ b/binaries/ehole/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/elvish/static.official.source.yaml
+++ b/binaries/elvish/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/elvish/static.official.source.yaml
+++ b/binaries/elvish/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enc/static.official.source.yaml
+++ b/binaries/enc/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enc/static.official.source.yaml
+++ b/binaries/enc/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/encode/static.official.source.yaml
+++ b/binaries/encode/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/encode/static.official.source.yaml
+++ b/binaries/encode/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enola/static.official.source.yaml
+++ b/binaries/enola/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enola/static.official.source.yaml
+++ b/binaries/enola/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enscan/static.official.source.yaml
+++ b/binaries/enscan/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enscan/static.official.source.yaml
+++ b/binaries/enscan/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enumeraga/static.official.source.yaml
+++ b/binaries/enumeraga/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enumeraga/static.official.source.yaml
+++ b/binaries/enumeraga/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enumerepo/static.official.source.yaml
+++ b/binaries/enumerepo/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/enumerepo/static.official.source.yaml
+++ b/binaries/enumerepo/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/epoch/static.official.source.yaml
+++ b/binaries/epoch/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/epoch/static.official.source.yaml
+++ b/binaries/epoch/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/esbuild/static.official.source.yaml
+++ b/binaries/esbuild/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/esbuild/static.official.source.yaml
+++ b/binaries/esbuild/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/exatorrent/static.official.source.yaml
+++ b/binaries/exatorrent/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/varbhat/exatorrent/raw/main/Makefile

--- a/binaries/exatorrent/static.official.source.yaml
+++ b/binaries/exatorrent/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/varbhat/exatorrent/raw/main/Makefile

--- a/binaries/exiflooter/static.official.source.yaml
+++ b/binaries/exiflooter/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/exiflooter/static.official.source.yaml
+++ b/binaries/exiflooter/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ezuri/static.official.source.yaml
+++ b/binaries/ezuri/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ezuri/static.official.source.yaml
+++ b/binaries/ezuri/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/f2/static.official.source.yaml
+++ b/binaries/f2/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/f2/static.official.source.yaml
+++ b/binaries/f2/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/falconhound/static.official.source.yaml
+++ b/binaries/falconhound/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/falconhound/static.official.source.yaml
+++ b/binaries/falconhound/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/favirecon/static.official.source.yaml
+++ b/binaries/favirecon/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/favirecon/static.official.source.yaml
+++ b/binaries/favirecon/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffuf-workflow/static.official.source.yaml
+++ b/binaries/ffuf-workflow/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffuf-workflow/static.official.source.yaml
+++ b/binaries/ffuf-workflow/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffuf/static.official.source.yaml
+++ b/binaries/ffuf/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffuf/static.official.source.yaml
+++ b/binaries/ffuf/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffufpostprocessing/static.official.source.yaml
+++ b/binaries/ffufpostprocessing/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffufpostprocessing/static.official.source.yaml
+++ b/binaries/ffufpostprocessing/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffufw/static.official.source.yaml
+++ b/binaries/ffufw/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ffufw/static.official.source.yaml
+++ b/binaries/ffufw/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fget/static.official.source.yaml
+++ b/binaries/fget/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fget/static.official.source.yaml
+++ b/binaries/fget/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fico/static.official.source.yaml
+++ b/binaries/fico/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fico/static.official.source.yaml
+++ b/binaries/fico/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/find-suid/static.official.source.yaml
+++ b/binaries/find-suid/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/find-suid/static.official.source.yaml
+++ b/binaries/find-suid/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fingerprintx/static.official.source.yaml
+++ b/binaries/fingerprintx/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fingerprintx/static.official.source.yaml
+++ b/binaries/fingerprintx/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/flyscrape/static.official.source.yaml
+++ b/binaries/flyscrape/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/flyscrape/static.official.source.yaml
+++ b/binaries/flyscrape/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fq/static.official.source.yaml
+++ b/binaries/fq/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fq/static.official.source.yaml
+++ b/binaries/fq/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/freeze/static.official.source.yaml
+++ b/binaries/freeze/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/freeze/static.official.source.yaml
+++ b/binaries/freeze/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/frp/static.official.source.yaml
+++ b/binaries/frp/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/frp/static.official.source.yaml
+++ b/binaries/frp/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fscan/static.official.source.yaml
+++ b/binaries/fscan/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fscan/static.official.source.yaml
+++ b/binaries/fscan/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fsize/static.official.source.yaml
+++ b/binaries/fsize/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fsize/static.official.source.yaml
+++ b/binaries/fsize/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ftpgrab/static.official.source.yaml
+++ b/binaries/ftpgrab/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ftpgrab/static.official.source.yaml
+++ b/binaries/ftpgrab/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fuzzuli/static.official.source.yaml
+++ b/binaries/fuzzuli/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fuzzuli/static.official.source.yaml
+++ b/binaries/fuzzuli/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fwanalyzer/static.official.source.yaml
+++ b/binaries/fwanalyzer/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fwanalyzer/static.official.source.yaml
+++ b/binaries/fwanalyzer/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fyne/static.official.source.yaml
+++ b/binaries/fyne/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/fyne/static.official.source.yaml
+++ b/binaries/fyne/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/galer/static.official.source.yaml
+++ b/binaries/galer/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/galer/static.official.source.yaml
+++ b/binaries/galer/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/garble/static.official.source.yaml
+++ b/binaries/garble/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/garble/static.official.source.yaml
+++ b/binaries/garble/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gau/static.official.source.yaml
+++ b/binaries/gau/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gau/static.official.source.yaml
+++ b/binaries/gau/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gdu/static.official.source.yaml
+++ b/binaries/gdu/static.official.source.yaml
@@ -67,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gdu/static.official.source.yaml
+++ b/binaries/gdu/static.official.source.yaml
@@ -67,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/getghrel/static.official.source.yaml
+++ b/binaries/getghrel/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/getghrel/static.official.source.yaml
+++ b/binaries/getghrel/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/getjs/static.official.source.yaml
+++ b/binaries/getjs/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/getjs/static.official.source.yaml
+++ b/binaries/getjs/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gf/static.official.source.yaml
+++ b/binaries/gf/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gf/static.official.source.yaml
+++ b/binaries/gf/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gf/static.rix4uni.source.yaml
+++ b/binaries/gf/static.rix4uni.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gf/static.rix4uni.source.yaml
+++ b/binaries/gf/static.rix4uni.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gfx/static.official.source.yaml
+++ b/binaries/gfx/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gfx/static.official.source.yaml
+++ b/binaries/gfx/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gh/static.official.source.yaml
+++ b/binaries/gh/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gh/static.official.source.yaml
+++ b/binaries/gh/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ghfetch/static.official.source.yaml
+++ b/binaries/ghfetch/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ghfetch/static.official.source.yaml
+++ b/binaries/ghfetch/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ghorg/static.official.source.yaml
+++ b/binaries/ghorg/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ghorg/static.official.source.yaml
+++ b/binaries/ghorg/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ghostunnel/static.official.source.yaml
+++ b/binaries/ghostunnel/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ghostunnel/static.official.source.yaml
+++ b/binaries/ghostunnel/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gickup/static.official.source.yaml
+++ b/binaries/gickup/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gickup/static.official.source.yaml
+++ b/binaries/gickup/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/git-sizer/static.official.source.yaml
+++ b/binaries/git-sizer/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/git-sizer/static.official.source.yaml
+++ b/binaries/git-sizer/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/git-who/static.official.source.yaml
+++ b/binaries/git-who/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/git-who/static.official.source.yaml
+++ b/binaries/git-who/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitdorks_go/static.official.source.yaml
+++ b/binaries/gitdorks_go/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitdorks_go/static.official.source.yaml
+++ b/binaries/gitdorks_go/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/github-endpoints/static.official.source.yaml
+++ b/binaries/github-endpoints/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/github-endpoints/static.official.source.yaml
+++ b/binaries/github-endpoints/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/github-regexp/static.official.source.yaml
+++ b/binaries/github-regexp/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/github-regexp/static.official.source.yaml
+++ b/binaries/github-regexp/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/github-subdomains/static.official.source.yaml
+++ b/binaries/github-subdomains/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/github-subdomains/static.official.source.yaml
+++ b/binaries/github-subdomains/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitlab-cli/static.official.source.yaml
+++ b/binaries/gitlab-cli/static.official.source.yaml
@@ -66,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitlab-cli/static.official.source.yaml
+++ b/binaries/gitlab-cli/static.official.source.yaml
@@ -66,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitlab-subdomains/static.official.source.yaml
+++ b/binaries/gitlab-subdomains/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitlab-subdomains/static.official.source.yaml
+++ b/binaries/gitlab-subdomains/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitleaks/static.official.source.yaml
+++ b/binaries/gitleaks/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitleaks/static.official.source.yaml
+++ b/binaries/gitleaks/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitql/static.official.source.yaml
+++ b/binaries/gitql/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitql/static.official.source.yaml
+++ b/binaries/gitql/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitty/static.official.source.yaml
+++ b/binaries/gitty/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gitty/static.official.source.yaml
+++ b/binaries/gitty/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/glider/static.official.source.yaml
+++ b/binaries/glider/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/glider/static.official.source.yaml
+++ b/binaries/glider/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/globalping-cli/static.official.source.yaml
+++ b/binaries/globalping-cli/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/globalping-cli/static.official.source.yaml
+++ b/binaries/globalping-cli/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/glow/static.official.source.yaml
+++ b/binaries/glow/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/glow/static.official.source.yaml
+++ b/binaries/glow/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-audit/static.official.source.yaml
+++ b/binaries/go-audit/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-audit/static.official.source.yaml
+++ b/binaries/go-audit/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-fasttld/static.official.source.yaml
+++ b/binaries/go-fasttld/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-fasttld/static.official.source.yaml
+++ b/binaries/go-fasttld/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-git/static.official.source.yaml
+++ b/binaries/go-git/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-git/static.official.source.yaml
+++ b/binaries/go-git/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-sandbox/static.official.source.yaml
+++ b/binaries/go-sandbox/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/go-sandbox/static.official.source.yaml
+++ b/binaries/go-sandbox/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/goawk/static.official.source.yaml
+++ b/binaries/goawk/static.official.source.yaml
@@ -46,6 +46,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -65,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/goawk/static.official.source.yaml
+++ b/binaries/goawk/static.official.source.yaml
@@ -66,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gobuster/static.dev.source.yaml
+++ b/binaries/gobuster/static.dev.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gobuster/static.dev.source.yaml
+++ b/binaries/gobuster/static.dev.source.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gobuster/static.official.source.yaml
+++ b/binaries/gobuster/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gobuster/static.official.source.yaml
+++ b/binaries/gobuster/static.official.source.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gobusybox/static.official.source.yaml
+++ b/binaries/gobusybox/static.official.source.yaml
@@ -46,6 +46,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -65,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build Tools

--- a/binaries/gobusybox/static.official.source.yaml
+++ b/binaries/gobusybox/static.official.source.yaml
@@ -66,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build Tools

--- a/binaries/gocryptfs/static.official.source.yaml
+++ b/binaries/gocryptfs/static.official.source.yaml
@@ -30,6 +30,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -49,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gocryptfs/static.official.source.yaml
+++ b/binaries/gocryptfs/static.official.source.yaml
@@ -50,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gocurl/static.official.source.yaml
+++ b/binaries/gocurl/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gocurl/static.official.source.yaml
+++ b/binaries/gocurl/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/godnsbench/static.official.source.yaml
+++ b/binaries/godnsbench/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/godnsbench/static.official.source.yaml
+++ b/binaries/godnsbench/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gofireprox/static.official.source.yaml
+++ b/binaries/gofireprox/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gofireprox/static.official.source.yaml
+++ b/binaries/gofireprox/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gogo/static.official.source.yaml
+++ b/binaries/gogo/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gogo/static.official.source.yaml
+++ b/binaries/gogo/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gojq/static.official.source.yaml
+++ b/binaries/gojq/static.official.source.yaml
@@ -67,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gojq/static.official.source.yaml
+++ b/binaries/gojq/static.official.source.yaml
@@ -47,6 +47,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -66,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gokr-rsync/static.official.source.yaml
+++ b/binaries/gokr-rsync/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gokr-rsync/static.official.source.yaml
+++ b/binaries/gokr-rsync/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/golin/static.official.source.yaml
+++ b/binaries/golin/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/golin/static.official.source.yaml
+++ b/binaries/golin/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/golinkfinder/static.official.source.yaml
+++ b/binaries/golinkfinder/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/golinkfinder/static.official.source.yaml
+++ b/binaries/golinkfinder/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gomuks/static.official.source.yaml
+++ b/binaries/gomuks/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gomuks/static.official.source.yaml
+++ b/binaries/gomuks/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/goodls/static.official.source.yaml
+++ b/binaries/goodls/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/goodls/static.official.source.yaml
+++ b/binaries/goodls/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/goop/static.official.source.yaml
+++ b/binaries/goop/static.official.source.yaml
@@ -30,6 +30,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -49,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/goop/static.official.source.yaml
+++ b/binaries/goop/static.official.source.yaml
@@ -50,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gopass/static.official.source.yaml
+++ b/binaries/gopass/static.official.source.yaml
@@ -64,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gopass/static.official.source.yaml
+++ b/binaries/gopass/static.official.source.yaml
@@ -44,6 +44,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -63,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gosearch/static.official.source.yaml
+++ b/binaries/gosearch/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gosearch/static.official.source.yaml
+++ b/binaries/gosearch/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gosec/static.official.source.yaml
+++ b/binaries/gosec/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gosec/static.official.source.yaml
+++ b/binaries/gosec/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gosmee/static.official.source.yaml
+++ b/binaries/gosmee/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gosmee/static.official.source.yaml
+++ b/binaries/gosmee/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gospider/static.official.source.yaml
+++ b/binaries/gospider/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gospider/static.official.source.yaml
+++ b/binaries/gospider/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gost/static.go-gost.source.yaml
+++ b/binaries/gost/static.go-gost.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gost/static.go-gost.source.yaml
+++ b/binaries/gost/static.go-gost.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gost/static.official.source.yaml
+++ b/binaries/gost/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gost/static.official.source.yaml
+++ b/binaries/gost/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gotator/static.official.source.yaml
+++ b/binaries/gotator/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gotator/static.official.source.yaml
+++ b/binaries/gotator/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gowitness/static.official.source.yaml
+++ b/binaries/gowitness/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gowitness/static.official.source.yaml
+++ b/binaries/gowitness/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gron/static.official.source.yaml
+++ b/binaries/gron/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gron/static.official.source.yaml
+++ b/binaries/gron/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gronx/static.official.source.yaml
+++ b/binaries/gronx/static.official.source.yaml
@@ -30,6 +30,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -49,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gronx/static.official.source.yaml
+++ b/binaries/gronx/static.official.source.yaml
@@ -50,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/grpcurl/static.official.source.yaml
+++ b/binaries/grpcurl/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/grpcurl/static.official.source.yaml
+++ b/binaries/grpcurl/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gstring/static.official.source.yaml
+++ b/binaries/gstring/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gstring/static.official.source.yaml
+++ b/binaries/gstring/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gum/static.official.source.yaml
+++ b/binaries/gum/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gum/static.official.source.yaml
+++ b/binaries/gum/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gungnir/static.official.source.yaml
+++ b/binaries/gungnir/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gungnir/static.official.source.yaml
+++ b/binaries/gungnir/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gup/static.official.source.yaml
+++ b/binaries/gup/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gup/static.official.source.yaml
+++ b/binaries/gup/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gxss/static.official.source.yaml
+++ b/binaries/gxss/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/gxss/static.official.source.yaml
+++ b/binaries/gxss/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hack-browser-data/static.official.source.yaml
+++ b/binaries/hack-browser-data/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hack-browser-data/static.official.source.yaml
+++ b/binaries/hack-browser-data/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hacker-scoper/static.official.source.yaml
+++ b/binaries/hacker-scoper/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hacker-scoper/static.official.source.yaml
+++ b/binaries/hacker-scoper/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakip2host/static.official.source.yaml
+++ b/binaries/hakip2host/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakip2host/static.official.source.yaml
+++ b/binaries/hakip2host/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakoriginfinder/static.official.source.yaml
+++ b/binaries/hakoriginfinder/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakoriginfinder/static.official.source.yaml
+++ b/binaries/hakoriginfinder/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakrawler/static.official.source.yaml
+++ b/binaries/hakrawler/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakrawler/static.official.source.yaml
+++ b/binaries/hakrawler/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakrevdns/static.official.source.yaml
+++ b/binaries/hakrevdns/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hakrevdns/static.official.source.yaml
+++ b/binaries/hakrevdns/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/haktrailsfree/static.official.source.yaml
+++ b/binaries/haktrailsfree/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/haktrailsfree/static.official.source.yaml
+++ b/binaries/haktrailsfree/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hcloud/static.official.source.yaml
+++ b/binaries/hcloud/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hcloud/static.official.source.yaml
+++ b/binaries/hcloud/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hednsextractor/static.official.source.yaml
+++ b/binaries/hednsextractor/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hednsextractor/static.official.source.yaml
+++ b/binaries/hednsextractor/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/herd/static.official.source.yaml
+++ b/binaries/herd/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/herd/static.official.source.yaml
+++ b/binaries/herd/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hostctl/static.official.source.yaml
+++ b/binaries/hostctl/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hostctl/static.official.source.yaml
+++ b/binaries/hostctl/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/htb-cli/static.official.source.yaml
+++ b/binaries/htb-cli/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/htb-cli/static.official.source.yaml
+++ b/binaries/htb-cli/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httprobe/static.official.source.yaml
+++ b/binaries/httprobe/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httprobe/static.official.source.yaml
+++ b/binaries/httprobe/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httpstat/static.official.source.yaml
+++ b/binaries/httpstat/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httpstat/static.official.source.yaml
+++ b/binaries/httpstat/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httptap/static.official.source.yaml
+++ b/binaries/httptap/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httptap/static.official.source.yaml
+++ b/binaries/httptap/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httpx/static.official.source.yaml
+++ b/binaries/httpx/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/httpx/static.official.source.yaml
+++ b/binaries/httpx/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hub/static.official.source.yaml
+++ b/binaries/hub/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hub/static.official.source.yaml
+++ b/binaries/hub/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hugo/static.official.source.yaml
+++ b/binaries/hugo/static.official.source.yaml
@@ -46,6 +46,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -65,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/hugo/static.official.source.yaml
+++ b/binaries/hugo/static.official.source.yaml
@@ -66,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/imgcat/static.official.source.yaml
+++ b/binaries/imgcat/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/imgcat/static.official.source.yaml
+++ b/binaries/imgcat/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/indextree/static.official.source.yaml
+++ b/binaries/indextree/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/indextree/static.official.source.yaml
+++ b/binaries/indextree/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ini-file/static.official.source.yaml
+++ b/binaries/ini-file/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ini-file/static.official.source.yaml
+++ b/binaries/ini-file/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/inscope/static.official.source.yaml
+++ b/binaries/inscope/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/inscope/static.official.source.yaml
+++ b/binaries/inscope/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/invidtui/static.official.source.yaml
+++ b/binaries/invidtui/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/invidtui/static.official.source.yaml
+++ b/binaries/invidtui/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ip_compact/static.official.source.yaml
+++ b/binaries/ip_compact/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ip_compact/static.official.source.yaml
+++ b/binaries/ip_compact/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ip_diff/static.official.source.yaml
+++ b/binaries/ip_diff/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ip_diff/static.official.source.yaml
+++ b/binaries/ip_diff/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ip_match/static.official.source.yaml
+++ b/binaries/ip_match/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ip_match/static.official.source.yaml
+++ b/binaries/ip_match/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ipa-server/static.official.source.yaml
+++ b/binaries/ipa-server/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ipa-server/static.official.source.yaml
+++ b/binaries/ipa-server/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/iphandle/static.official.source.yaml
+++ b/binaries/iphandle/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/iphandle/static.official.source.yaml
+++ b/binaries/iphandle/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ipinfo/static.official.source.yaml
+++ b/binaries/ipinfo/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ipinfo/static.official.source.yaml
+++ b/binaries/ipinfo/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ipspinner/static.official.source.yaml
+++ b/binaries/ipspinner/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ipspinner/static.official.source.yaml
+++ b/binaries/ipspinner/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/is/static.official.source.yaml
+++ b/binaries/is/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/is/static.official.source.yaml
+++ b/binaries/is/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jaeles/static.official.source.yaml
+++ b/binaries/jaeles/static.official.source.yaml
@@ -30,6 +30,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -49,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jaeles/static.official.source.yaml
+++ b/binaries/jaeles/static.official.source.yaml
@@ -50,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jd/static.official.source.yaml
+++ b/binaries/jd/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jd/static.official.source.yaml
+++ b/binaries/jd/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jira-cli/static.official.source.yaml
+++ b/binaries/jira-cli/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jira-cli/static.official.source.yaml
+++ b/binaries/jira-cli/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jqp/static.official.source.yaml
+++ b/binaries/jqp/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jqp/static.official.source.yaml
+++ b/binaries/jqp/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jr/static.official.source.yaml
+++ b/binaries/jr/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/jrnd-io/jr/raw/main/Makefile

--- a/binaries/jr/static.official.source.yaml
+++ b/binaries/jr/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/jrnd-io/jr/raw/main/Makefile

--- a/binaries/jsdif/static.official.source.yaml
+++ b/binaries/jsdif/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jsdif/static.official.source.yaml
+++ b/binaries/jsdif/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jsluice/static.official.source.yaml
+++ b/binaries/jsluice/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jsluice/static.official.source.yaml
+++ b/binaries/jsluice/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/json-cleaner/static.official.source.yaml
+++ b/binaries/json-cleaner/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/json-cleaner/static.official.source.yaml
+++ b/binaries/json-cleaner/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jwt-hack/static.official.source.yaml
+++ b/binaries/jwt-hack/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/jwt-hack/static.official.source.yaml
+++ b/binaries/jwt-hack/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/k9s/static.official.stable.yaml
+++ b/binaries/k9s/static.official.stable.yaml
@@ -64,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/k9s/static.official.stable.yaml
+++ b/binaries/k9s/static.official.stable.yaml
@@ -44,6 +44,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -63,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/katana/static.official.source.yaml
+++ b/binaries/katana/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/katana/static.official.source.yaml
+++ b/binaries/katana/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/kcptun/static.official.source.yaml
+++ b/binaries/kcptun/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/kcptun/static.official.source.yaml
+++ b/binaries/kcptun/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/keep-sorted/static.official.source.yaml
+++ b/binaries/keep-sorted/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/keep-sorted/static.official.source.yaml
+++ b/binaries/keep-sorted/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ksubdomain/static.official.source.yaml
+++ b/binaries/ksubdomain/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ksubdomain/static.official.source.yaml
+++ b/binaries/ksubdomain/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/kubo/static.official.source.yaml
+++ b/binaries/kubo/static.official.source.yaml
@@ -67,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/kubo/static.official.source.yaml
+++ b/binaries/kubo/static.official.source.yaml
@@ -47,6 +47,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -66,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ladder/static.official.source.yaml
+++ b/binaries/ladder/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ladder/static.official.source.yaml
+++ b/binaries/ladder/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/landrun/static.official.source.yaml
+++ b/binaries/landrun/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/landrun/static.official.source.yaml
+++ b/binaries/landrun/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lazydocker/static.official.source.yaml
+++ b/binaries/lazydocker/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lazydocker/static.official.source.yaml
+++ b/binaries/lazydocker/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lazygit/static.official.source.yaml
+++ b/binaries/lazygit/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lazygit/static.official.source.yaml
+++ b/binaries/lazygit/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lazyjournal/static.official.source.yaml
+++ b/binaries/lazyjournal/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lazyjournal/static.official.source.yaml
+++ b/binaries/lazyjournal/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lc/static.official.source.yaml
+++ b/binaries/lc/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lc/static.official.source.yaml
+++ b/binaries/lc/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lf/static.official.stable.yaml
+++ b/binaries/lf/static.official.stable.yaml
@@ -48,6 +48,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -67,7 +68,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lf/static.official.stable.yaml
+++ b/binaries/lf/static.official.stable.yaml
@@ -68,7 +68,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/libaws-cli/static.official.source.yaml
+++ b/binaries/libaws-cli/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/libaws-cli/static.official.source.yaml
+++ b/binaries/libaws-cli/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ligolo-ng/static.official.source.yaml
+++ b/binaries/ligolo-ng/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ligolo-ng/static.official.source.yaml
+++ b/binaries/ligolo-ng/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lilipod/static.official.source.yaml
+++ b/binaries/lilipod/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/89luca89/lilipod/blob/main/Makefile

--- a/binaries/lilipod/static.official.source.yaml
+++ b/binaries/lilipod/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/89luca89/lilipod/blob/main/Makefile

--- a/binaries/lit-bb-hack-tools/static.official.source.yaml
+++ b/binaries/lit-bb-hack-tools/static.official.source.yaml
@@ -107,7 +107,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lit-bb-hack-tools/static.official.source.yaml
+++ b/binaries/lit-bb-hack-tools/static.official.source.yaml
@@ -87,6 +87,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -106,7 +107,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/litefs/static.official.source.yaml
+++ b/binaries/litefs/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/litefs/static.official.source.yaml
+++ b/binaries/litefs/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/litestream/static.official.source.yaml
+++ b/binaries/litestream/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/litestream/static.official.source.yaml
+++ b/binaries/litestream/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/logdy/static.official.source.yaml
+++ b/binaries/logdy/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/logdy/static.official.source.yaml
+++ b/binaries/logdy/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/logtimer/static.official.source.yaml
+++ b/binaries/logtimer/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/logtimer/static.official.source.yaml
+++ b/binaries/logtimer/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/luet/static.official.source.yaml
+++ b/binaries/luet/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/luet/static.official.source.yaml
+++ b/binaries/luet/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lux/static.official.source.yaml
+++ b/binaries/lux/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/lux/static.official.source.yaml
+++ b/binaries/lux/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mabel/static.official.source.yaml
+++ b/binaries/mabel/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mabel/static.official.source.yaml
+++ b/binaries/mabel/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/maddy/static.official.source.yaml
+++ b/binaries/maddy/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/maddy/static.official.source.yaml
+++ b/binaries/maddy/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mani/static.official.source.yaml
+++ b/binaries/mani/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mani/static.official.source.yaml
+++ b/binaries/mani/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/manifest-tool/static.official.source.yaml
+++ b/binaries/manifest-tool/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/manifest-tool/static.official.source.yaml
+++ b/binaries/manifest-tool/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mantra/static.official.source.yaml
+++ b/binaries/mantra/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mantra/static.official.source.yaml
+++ b/binaries/mantra/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mapcidr/static.official.source.yaml
+++ b/binaries/mapcidr/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mapcidr/static.official.source.yaml
+++ b/binaries/mapcidr/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/matterbridge/static.official.source.yaml
+++ b/binaries/matterbridge/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/matterbridge/static.official.source.yaml
+++ b/binaries/matterbridge/static.official.source.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mc/static.official.source.yaml
+++ b/binaries/mc/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mc/static.official.source.yaml
+++ b/binaries/mc/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/melange/static.official.source.yaml
+++ b/binaries/melange/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/melange/static.official.source.yaml
+++ b/binaries/melange/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/metabigor/static.official.source.yaml
+++ b/binaries/metabigor/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/metabigor/static.official.source.yaml
+++ b/binaries/metabigor/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mgwls/static.official.source.yaml
+++ b/binaries/mgwls/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mgwls/static.official.source.yaml
+++ b/binaries/mgwls/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/micro/static.official.source.yaml
+++ b/binaries/micro/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/micro/static.official.source.yaml
+++ b/binaries/micro/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mieru/static.official.source.yaml
+++ b/binaries/mieru/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mieru/static.official.source.yaml
+++ b/binaries/mieru/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/miller/static.official.source.yaml
+++ b/binaries/miller/static.official.source.yaml
@@ -67,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/miller/static.official.source.yaml
+++ b/binaries/miller/static.official.source.yaml
@@ -47,6 +47,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -66,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/miniflux/static.official.source.yaml
+++ b/binaries/miniflux/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/miniflux/static.official.source.yaml
+++ b/binaries/miniflux/static.official.source.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/minify/static.official.source.yaml
+++ b/binaries/minify/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/minify/static.official.source.yaml
+++ b/binaries/minify/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/minio-warp/static.official.source.yaml
+++ b/binaries/minio-warp/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/minio-warp/static.official.source.yaml
+++ b/binaries/minio-warp/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mirrorbits/static.official.source.yaml
+++ b/binaries/mirrorbits/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mirrorbits/static.official.source.yaml
+++ b/binaries/mirrorbits/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mksub/static.official.source.yaml
+++ b/binaries/mksub/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mksub/static.official.source.yaml
+++ b/binaries/mksub/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mmv/static.official.source.yaml
+++ b/binaries/mmv/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mmv/static.official.source.yaml
+++ b/binaries/mmv/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/moac/static.official.source.yaml
+++ b/binaries/moac/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/moac/static.official.source.yaml
+++ b/binaries/moac/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/morrigan/static.official.source.yaml
+++ b/binaries/morrigan/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/morrigan/static.official.source.yaml
+++ b/binaries/morrigan/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mubeng/static.official.source.yaml
+++ b/binaries/mubeng/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mubeng/static.official.source.yaml
+++ b/binaries/mubeng/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/muffet/static.official.source.yaml
+++ b/binaries/muffet/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/muffet/static.official.source.yaml
+++ b/binaries/muffet/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mult/static.official.source.yaml
+++ b/binaries/mult/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mult/static.official.source.yaml
+++ b/binaries/mult/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mup/static.official.source.yaml
+++ b/binaries/mup/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/mup/static.official.source.yaml
+++ b/binaries/mup/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/naabu/static.official.source.yaml
+++ b/binaries/naabu/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/naabu/static.official.source.yaml
+++ b/binaries/naabu/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/namegen/static.official.source.yaml
+++ b/binaries/namegen/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/namegen/static.official.source.yaml
+++ b/binaries/namegen/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nerdctl/static.official.source.yaml
+++ b/binaries/nerdctl/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nerdctl/static.official.source.yaml
+++ b/binaries/nerdctl/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/netbird/static.official.source.yaml
+++ b/binaries/netbird/static.official.source.yaml
@@ -67,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/netbird/static.official.source.yaml
+++ b/binaries/netbird/static.official.source.yaml
@@ -47,6 +47,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -66,7 +67,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/netmaker/static.official.source.yaml
+++ b/binaries/netmaker/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/netmaker/static.official.source.yaml
+++ b/binaries/netmaker/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nfpm/static.official.source.yaml
+++ b/binaries/nfpm/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nfpm/static.official.source.yaml
+++ b/binaries/nfpm/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ngocok/static.official.source.yaml
+++ b/binaries/ngocok/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ngocok/static.official.source.yaml
+++ b/binaries/ngocok/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nmap-formatter/static.official.source.yaml
+++ b/binaries/nmap-formatter/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nmap-formatter/static.official.source.yaml
+++ b/binaries/nmap-formatter/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nmapurls/static.official.source.yaml
+++ b/binaries/nmapurls/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nmapurls/static.official.source.yaml
+++ b/binaries/nmapurls/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nodepass/static.official.source.yaml
+++ b/binaries/nodepass/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nodepass/static.official.source.yaml
+++ b/binaries/nodepass/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nomore403/static.official.source.yaml
+++ b/binaries/nomore403/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nomore403/static.official.source.yaml
+++ b/binaries/nomore403/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/notify/static.official.source.yaml
+++ b/binaries/notify/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/notify/static.official.source.yaml
+++ b/binaries/notify/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ntask/static.official.source.yaml
+++ b/binaries/ntask/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ntask/static.official.source.yaml
+++ b/binaries/ntask/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nuclei/static.official.source.yaml
+++ b/binaries/nuclei/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/nuclei/static.official.source.yaml
+++ b/binaries/nuclei/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/onctl/static.official.source.yaml
+++ b/binaries/onctl/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/onctl/static.official.source.yaml
+++ b/binaries/onctl/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/onionpipe/static.official.source.yaml
+++ b/binaries/onionpipe/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/onionpipe/static.official.source.yaml
+++ b/binaries/onionpipe/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ooniprobe/static.official.source.yaml
+++ b/binaries/ooniprobe/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ooniprobe/static.official.source.yaml
+++ b/binaries/ooniprobe/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/oosexclude/static.official.source.yaml
+++ b/binaries/oosexclude/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/oosexclude/static.official.source.yaml
+++ b/binaries/oosexclude/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/opengfw/static.official.source.yaml
+++ b/binaries/opengfw/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/opengfw/static.official.source.yaml
+++ b/binaries/opengfw/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/openrisk/static.official.source.yaml
+++ b/binaries/openrisk/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/openrisk/static.official.source.yaml
+++ b/binaries/openrisk/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/oras/static.official.source.yaml
+++ b/binaries/oras/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/oras/static.official.source.yaml
+++ b/binaries/oras/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/org2asn/static.official.source.yaml
+++ b/binaries/org2asn/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/org2asn/static.official.source.yaml
+++ b/binaries/org2asn/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/osmedeus/static.official.source.yaml
+++ b/binaries/osmedeus/static.official.source.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/osmedeus/static.official.source.yaml
+++ b/binaries/osmedeus/static.official.source.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ov/static.official.source.yaml
+++ b/binaries/ov/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ov/static.official.source.yaml
+++ b/binaries/ov/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/passdetective/static.official.source.yaml
+++ b/binaries/passdetective/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/passdetective/static.official.source.yaml
+++ b/binaries/passdetective/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pdfcpu/static.official.source.yaml
+++ b/binaries/pdfcpu/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pdfcpu/static.official.source.yaml
+++ b/binaries/pdfcpu/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pdtm/static.official.source.yaml
+++ b/binaries/pdtm/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pdtm/static.official.source.yaml
+++ b/binaries/pdtm/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pencode/static.official.source.yaml
+++ b/binaries/pencode/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pencode/static.official.source.yaml
+++ b/binaries/pencode/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pet/static.official.source.yaml
+++ b/binaries/pet/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pet/static.official.source.yaml
+++ b/binaries/pet/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/picocrypt/static.official.source.yaml
+++ b/binaries/picocrypt/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/picocrypt/static.official.source.yaml
+++ b/binaries/picocrypt/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pingtunnel/static.official.source.yaml
+++ b/binaries/pingtunnel/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pingtunnel/static.official.source.yaml
+++ b/binaries/pingtunnel/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pixterm/static.official.source.yaml
+++ b/binaries/pixterm/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pixterm/static.official.source.yaml
+++ b/binaries/pixterm/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pkgtop/static.official.source.yaml
+++ b/binaries/pkgtop/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pkgtop/static.official.source.yaml
+++ b/binaries/pkgtop/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pktstat/static.official.source.yaml
+++ b/binaries/pktstat/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pktstat/static.official.source.yaml
+++ b/binaries/pktstat/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/planor/static.official.source.yaml
+++ b/binaries/planor/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/planor/static.official.source.yaml
+++ b/binaries/planor/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/podsync/static.official.source.yaml
+++ b/binaries/podsync/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/podsync/static.official.source.yaml
+++ b/binaries/podsync/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/portmap/static.rix4uni.source.yaml
+++ b/binaries/portmap/static.rix4uni.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/portmap/static.rix4uni.source.yaml
+++ b/binaries/portmap/static.rix4uni.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ppath/static.official.source.yaml
+++ b/binaries/ppath/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ppath/static.official.source.yaml
+++ b/binaries/ppath/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pphack/static.official.source.yaml
+++ b/binaries/pphack/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pphack/static.official.source.yaml
+++ b/binaries/pphack/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ppmap/static.official.source.yaml
+++ b/binaries/ppmap/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ppmap/static.official.source.yaml
+++ b/binaries/ppmap/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/protocurl/static.official.source.yaml
+++ b/binaries/protocurl/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/protocurl/static.official.source.yaml
+++ b/binaries/protocurl/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/proxify/static.official.source.yaml
+++ b/binaries/proxify/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/proxify/static.official.source.yaml
+++ b/binaries/proxify/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/proxy-ns/static.official.source.yaml
+++ b/binaries/proxy-ns/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/proxy-ns/static.official.source.yaml
+++ b/binaries/proxy-ns/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pspy/static.official.source.yaml
+++ b/binaries/pspy/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pspy/static.official.source.yaml
+++ b/binaries/pspy/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/puredns/static.official.source.yaml
+++ b/binaries/puredns/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/puredns/static.official.source.yaml
+++ b/binaries/puredns/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pwdsafety/static.official.source.yaml
+++ b/binaries/pwdsafety/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/pwdsafety/static.official.source.yaml
+++ b/binaries/pwdsafety/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/q/static.official.source.yaml
+++ b/binaries/q/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/q/static.official.source.yaml
+++ b/binaries/q/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/qp/static.official.source.yaml
+++ b/binaries/qp/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/qp/static.official.source.yaml
+++ b/binaries/qp/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/qq/static.official.source.yaml
+++ b/binaries/qq/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/qq/static.official.source.yaml
+++ b/binaries/qq/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/qsreplace/static.official.source.yaml
+++ b/binaries/qsreplace/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/qsreplace/static.official.source.yaml
+++ b/binaries/qsreplace/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/quickcert/static.official.source.yaml
+++ b/binaries/quickcert/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/quickcert/static.official.source.yaml
+++ b/binaries/quickcert/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/quotes-escaper/static.official.source.yaml
+++ b/binaries/quotes-escaper/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/quotes-escaper/static.official.source.yaml
+++ b/binaries/quotes-escaper/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rate-limit-checker/static.official.source.yaml
+++ b/binaries/rate-limit-checker/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rate-limit-checker/static.official.source.yaml
+++ b/binaries/rate-limit-checker/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rdap-client/static.official.source.yaml
+++ b/binaries/rdap-client/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rdap-client/static.official.source.yaml
+++ b/binaries/rdap-client/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/reader/static.official.source.yaml
+++ b/binaries/reader/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/reader/static.official.source.yaml
+++ b/binaries/reader/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/redguard/static.official.source.yaml
+++ b/binaries/redguard/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/redguard/static.official.source.yaml
+++ b/binaries/redguard/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/regclient/static.official.source.yaml
+++ b/binaries/regclient/static.official.source.yaml
@@ -71,7 +71,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/regclient/static.official.source.yaml
+++ b/binaries/regclient/static.official.source.yaml
@@ -51,6 +51,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -70,7 +71,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rekor/static.official.source.yaml
+++ b/binaries/rekor/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rekor/static.official.source.yaml
+++ b/binaries/rekor/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/relic/static.official.source.yaml
+++ b/binaries/relic/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/relic/static.official.source.yaml
+++ b/binaries/relic/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rescope/static.official.source.yaml
+++ b/binaries/rescope/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rescope/static.official.source.yaml
+++ b/binaries/rescope/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/restic/static.official.stable.yaml
+++ b/binaries/restic/static.official.stable.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/restic/static.official.stable.yaml
+++ b/binaries/restic/static.official.stable.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/resto/static.official.source.yaml
+++ b/binaries/resto/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/resto/static.official.source.yaml
+++ b/binaries/resto/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/reverse_ssh/static.official.source.yaml
+++ b/binaries/reverse_ssh/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/reverse_ssh/static.official.source.yaml
+++ b/binaries/reverse_ssh/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/reviewdog/static.official.source.yaml
+++ b/binaries/reviewdog/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/reviewdog/static.official.source.yaml
+++ b/binaries/reviewdog/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/revive/static.official.source.yaml
+++ b/binaries/revive/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/revive/static.official.source.yaml
+++ b/binaries/revive/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/roboxtractor/static.official.source.yaml
+++ b/binaries/roboxtractor/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/roboxtractor/static.official.source.yaml
+++ b/binaries/roboxtractor/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rootlesskit/static.official.source.yaml
+++ b/binaries/rootlesskit/static.official.source.yaml
@@ -48,6 +48,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -67,7 +68,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rootlesskit/static.official.source.yaml
+++ b/binaries/rootlesskit/static.official.source.yaml
@@ -68,7 +68,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rospo/static.official.source.yaml
+++ b/binaries/rospo/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rospo/static.official.source.yaml
+++ b/binaries/rospo/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/routedns/static.official.source.yaml
+++ b/binaries/routedns/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/routedns/static.official.source.yaml
+++ b/binaries/routedns/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/runc/static.official.source.yaml
+++ b/binaries/runc/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/runc/static.official.source.yaml
+++ b/binaries/runc/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rush/static.official.source.yaml
+++ b/binaries/rush/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/rush/static.official.source.yaml
+++ b/binaries/rush/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/s3scanner/static.official.source.yaml
+++ b/binaries/s3scanner/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/s3scanner/static.official.source.yaml
+++ b/binaries/s3scanner/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/s3sync/static.official.source.yaml
+++ b/binaries/s3sync/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/s3sync/static.official.source.yaml
+++ b/binaries/s3sync/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/s5cmd/static.official.source.yaml
+++ b/binaries/s5cmd/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/s5cmd/static.official.source.yaml
+++ b/binaries/s5cmd/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sake/static.official.source.yaml
+++ b/binaries/sake/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sake/static.official.source.yaml
+++ b/binaries/sake/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sastsweep/static.official.source.yaml
+++ b/binaries/sastsweep/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sastsweep/static.official.source.yaml
+++ b/binaries/sastsweep/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sbctl/static.official.source.yaml
+++ b/binaries/sbctl/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sbctl/static.official.source.yaml
+++ b/binaries/sbctl/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/scilla/static.official.source.yaml
+++ b/binaries/scilla/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/scilla/static.official.source.yaml
+++ b/binaries/scilla/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/scopegen/static.official.source.yaml
+++ b/binaries/scopegen/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/scopegen/static.official.source.yaml
+++ b/binaries/scopegen/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/screener/static.official.source.yaml
+++ b/binaries/screener/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/screener/static.official.source.yaml
+++ b/binaries/screener/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sdns/static.official.source.yaml
+++ b/binaries/sdns/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        apk add binutils-gold --latest --upgrade --no-interactive
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sdns/static.official.source.yaml
+++ b/binaries/sdns/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        apk add binutils-gold --latest --upgrade --no-interactive
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sequin/static.official.source.yaml
+++ b/binaries/sequin/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sequin/static.official.source.yaml
+++ b/binaries/sequin/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sessionprobe/static.official.source.yaml
+++ b/binaries/sessionprobe/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sessionprobe/static.official.source.yaml
+++ b/binaries/sessionprobe/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shcopy/static.official.source.yaml
+++ b/binaries/shcopy/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shcopy/static.official.source.yaml
+++ b/binaries/shcopy/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shell2http/static.official.source.yaml
+++ b/binaries/shell2http/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shell2http/static.official.source.yaml
+++ b/binaries/shell2http/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shellz/static.official.source.yaml
+++ b/binaries/shellz/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shellz/static.official.source.yaml
+++ b/binaries/shellz/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shfmt/static.official.source.yaml
+++ b/binaries/shfmt/static.official.source.yaml
@@ -43,6 +43,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -62,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shfmt/static.official.source.yaml
+++ b/binaries/shfmt/static.official.source.yaml
@@ -63,7 +63,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shortscan/static.official.source.yaml
+++ b/binaries/shortscan/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shortscan/static.official.source.yaml
+++ b/binaries/shortscan/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shuffledns/static.official.source.yaml
+++ b/binaries/shuffledns/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/shuffledns/static.official.source.yaml
+++ b/binaries/shuffledns/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/siegfried/static.official.source.yaml
+++ b/binaries/siegfried/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/siegfried/static.official.source.yaml
+++ b/binaries/siegfried/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/simplehttpserver/static.go.source.yaml
+++ b/binaries/simplehttpserver/static.go.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/simplehttpserver/static.go.source.yaml
+++ b/binaries/simplehttpserver/static.go.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sing-box/static.official.source.yaml
+++ b/binaries/sing-box/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build:https://github.com/SagerNet/sing-box/raw/dev-next/Dockerfile

--- a/binaries/sing-box/static.official.source.yaml
+++ b/binaries/sing-box/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build:https://github.com/SagerNet/sing-box/raw/dev-next/Dockerfile

--- a/binaries/sish/static.official.source.yaml
+++ b/binaries/sish/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sish/static.official.source.yaml
+++ b/binaries/sish/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sj/static.official.source.yaml
+++ b/binaries/sj/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sj/static.official.source.yaml
+++ b/binaries/sj/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/skopeo/static.official.source.yaml
+++ b/binaries/skopeo/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe -D_LARGEFILE64_SOURCE"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/containers/skopeo/blob/main/install.md

--- a/binaries/skopeo/static.official.source.yaml
+++ b/binaries/skopeo/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe -D_LARGEFILE64_SOURCE"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build: https://github.com/containers/skopeo/blob/main/install.md

--- a/binaries/skupper/static.official.source.yaml
+++ b/binaries/skupper/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/skupper/static.official.source.yaml
+++ b/binaries/skupper/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/slim/static.official.source.yaml
+++ b/binaries/slim/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/slim/static.official.source.yaml
+++ b/binaries/slim/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sling/static.official.source.yaml
+++ b/binaries/sling/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sling/static.official.source.yaml
+++ b/binaries/sling/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sliver/static.official.source.yaml
+++ b/binaries/sliver/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sliver/static.official.source.yaml
+++ b/binaries/sliver/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/smap/static.official.source.yaml
+++ b/binaries/smap/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/smap/static.official.source.yaml
+++ b/binaries/smap/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sns/static.official.source.yaml
+++ b/binaries/sns/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sns/static.official.source.yaml
+++ b/binaries/sns/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/soft-serve/static.official.source.yaml
+++ b/binaries/soft-serve/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/soft-serve/static.official.source.yaml
+++ b/binaries/soft-serve/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sops/static.official.source.yaml
+++ b/binaries/sops/static.official.source.yaml
@@ -64,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sops/static.official.source.yaml
+++ b/binaries/sops/static.official.source.yaml
@@ -44,6 +44,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -63,7 +64,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sourcemapper/static.official.source.yaml
+++ b/binaries/sourcemapper/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sourcemapper/static.official.source.yaml
+++ b/binaries/sourcemapper/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/speedtest-go/static.official.source.yaml
+++ b/binaries/speedtest-go/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/speedtest-go/static.official.source.yaml
+++ b/binaries/speedtest-go/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/spk/static.official.source.yaml
+++ b/binaries/spk/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/spk/static.official.source.yaml
+++ b/binaries/spk/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/spoofdpi/static.official.source.yaml
+++ b/binaries/spoofdpi/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/spoofdpi/static.official.source.yaml
+++ b/binaries/spoofdpi/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/spray/static.official.source.yaml
+++ b/binaries/spray/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/spray/static.official.source.yaml
+++ b/binaries/spray/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sprayshark/static.official.source.yaml
+++ b/binaries/sprayshark/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sprayshark/static.official.source.yaml
+++ b/binaries/sprayshark/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sq/static.official.source.yaml
+++ b/binaries/sq/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sq/static.official.source.yaml
+++ b/binaries/sq/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sqlc/static.official.source.yaml
+++ b/binaries/sqlc/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sqlc/static.official.source.yaml
+++ b/binaries/sqlc/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ssh-key-sync/static.official.source.yaml
+++ b/binaries/ssh-key-sync/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ssh-key-sync/static.official.source.yaml
+++ b/binaries/ssh-key-sync/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshamble/static.official.source.yaml
+++ b/binaries/sshamble/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshamble/static.official.source.yaml
+++ b/binaries/sshamble/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshesame/static.official.source.yaml
+++ b/binaries/sshesame/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshesame/static.official.source.yaml
+++ b/binaries/sshesame/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshkeys/static.official.source.yaml
+++ b/binaries/sshkeys/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshkeys/static.official.source.yaml
+++ b/binaries/sshkeys/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshpass-go/static.official.source.yaml
+++ b/binaries/sshpass-go/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshpass-go/static.official.source.yaml
+++ b/binaries/sshpass-go/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshpiperd/static.official.source.yaml
+++ b/binaries/sshpiperd/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshpiperd/static.official.source.yaml
+++ b/binaries/sshpiperd/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshportal/static.official.source.yaml
+++ b/binaries/sshportal/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sshportal/static.official.source.yaml
+++ b/binaries/sshportal/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sslsearch/static.official.source.yaml
+++ b/binaries/sslsearch/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sslsearch/static.official.source.yaml
+++ b/binaries/sslsearch/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/steampipe/static.official.source.yaml
+++ b/binaries/steampipe/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/steampipe/static.official.source.yaml
+++ b/binaries/steampipe/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/step-cli/static.official.source.yaml
+++ b/binaries/step-cli/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/step-cli/static.official.source.yaml
+++ b/binaries/step-cli/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stew/static.official.source.yaml
+++ b/binaries/stew/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stew/static.official.source.yaml
+++ b/binaries/stew/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stowaway/static.official.source.yaml
+++ b/binaries/stowaway/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stowaway/static.official.source.yaml
+++ b/binaries/stowaway/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stree/static.official.source.yaml
+++ b/binaries/stree/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stree/static.official.source.yaml
+++ b/binaries/stree/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sttr/static.official.source.yaml
+++ b/binaries/sttr/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sttr/static.official.source.yaml
+++ b/binaries/sttr/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stuffbin/static.official.source.yaml
+++ b/binaries/stuffbin/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stuffbin/static.official.source.yaml
+++ b/binaries/stuffbin/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stunner/static.official.source.yaml
+++ b/binaries/stunner/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/stunner/static.official.source.yaml
+++ b/binaries/stunner/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subdog/static.official.source.yaml
+++ b/binaries/subdog/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subdog/static.official.source.yaml
+++ b/binaries/subdog/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subfinder/static.official.source.yaml
+++ b/binaries/subfinder/static.official.source.yaml
@@ -41,6 +41,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -60,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subfinder/static.official.source.yaml
+++ b/binaries/subfinder/static.official.source.yaml
@@ -61,7 +61,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subjs/static.official.source.yaml
+++ b/binaries/subjs/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subjs/static.official.source.yaml
+++ b/binaries/subjs/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subs/static.official.source.yaml
+++ b/binaries/subs/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subs/static.official.source.yaml
+++ b/binaries/subs/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subxtract/static.official.source.yaml
+++ b/binaries/subxtract/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/subxtract/static.official.source.yaml
+++ b/binaries/subxtract/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sugarfree/static.official.source.yaml
+++ b/binaries/sugarfree/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sugarfree/static.official.source.yaml
+++ b/binaries/sugarfree/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sunbeam/static.official.source.yaml
+++ b/binaries/sunbeam/static.official.source.yaml
@@ -50,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/sunbeam/static.official.source.yaml
+++ b/binaries/sunbeam/static.official.source.yaml
@@ -30,6 +30,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -49,7 +50,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/supercronic/static.official.source.yaml
+++ b/binaries/supercronic/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/supercronic/static.official.source.yaml
+++ b/binaries/supercronic/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/supernova/static.official.source.yaml
+++ b/binaries/supernova/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/supernova/static.official.source.yaml
+++ b/binaries/supernova/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/supervisord/static.official.source.yaml
+++ b/binaries/supervisord/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/supervisord/static.official.source.yaml
+++ b/binaries/supervisord/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/surf/static.official.source.yaml
+++ b/binaries/surf/static.official.source.yaml
@@ -27,6 +27,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -46,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/surf/static.official.source.yaml
+++ b/binaries/surf/static.official.source.yaml
@@ -47,7 +47,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/taierspeed-cli/static.official.source.yaml
+++ b/binaries/taierspeed-cli/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/taierspeed-cli/static.official.source.yaml
+++ b/binaries/taierspeed-cli/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tailscale/static.official.source.yaml
+++ b/binaries/tailscale/static.official.source.yaml
@@ -76,7 +76,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tailscale/static.official.source.yaml
+++ b/binaries/tailscale/static.official.source.yaml
@@ -76,7 +76,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tar-split/static.official.source.yaml
+++ b/binaries/tar-split/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tar-split/static.official.source.yaml
+++ b/binaries/tar-split/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/teldrive/static.official.source.yaml
+++ b/binaries/teldrive/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/teldrive/static.official.source.yaml
+++ b/binaries/teldrive/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/termshark/static.official.source.yaml
+++ b/binaries/termshark/static.official.source.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/termshark/static.official.source.yaml
+++ b/binaries/termshark/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tget/static.official.source.yaml
+++ b/binaries/tget/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tget/static.official.source.yaml
+++ b/binaries/tget/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tgpt/static.official.source.yaml
+++ b/binaries/tgpt/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tgpt/static.official.source.yaml
+++ b/binaries/tgpt/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/timelimitx/static.official.source.yaml
+++ b/binaries/timelimitx/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/timelimitx/static.official.source.yaml
+++ b/binaries/timelimitx/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/timer/static.official.source.yaml
+++ b/binaries/timer/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/timer/static.official.source.yaml
+++ b/binaries/timer/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tinja/static.official.source.yaml
+++ b/binaries/tinja/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tinja/static.official.source.yaml
+++ b/binaries/tinja/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tlder/static.official.source.yaml
+++ b/binaries/tlder/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tlder/static.official.source.yaml
+++ b/binaries/tlder/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tldfinder/static.official.source.yaml
+++ b/binaries/tldfinder/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tldfinder/static.official.source.yaml
+++ b/binaries/tldfinder/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tldscan/static.official.source.yaml
+++ b/binaries/tldscan/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tldscan/static.official.source.yaml
+++ b/binaries/tldscan/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tlsx/static.official.source.yaml
+++ b/binaries/tlsx/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tlsx/static.official.source.yaml
+++ b/binaries/tlsx/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tok/static.official.source.yaml
+++ b/binaries/tok/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tok/static.official.source.yaml
+++ b/binaries/tok/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/toru/static.official.source.yaml
+++ b/binaries/toru/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/toru/static.official.source.yaml
+++ b/binaries/toru/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/transfersh/static.official.source.yaml
+++ b/binaries/transfersh/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/transfersh/static.official.source.yaml
+++ b/binaries/transfersh/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/trufflehog/static.official.source.yaml
+++ b/binaries/trufflehog/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/trufflehog/static.official.source.yaml
+++ b/binaries/trufflehog/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tssh/static.official.source.yaml
+++ b/binaries/tssh/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tssh/static.official.source.yaml
+++ b/binaries/tssh/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tty2web/static.official.source.yaml
+++ b/binaries/tty2web/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tty2web/static.official.source.yaml
+++ b/binaries/tty2web/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ttyimg/static.official.source.yaml
+++ b/binaries/ttyimg/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/ttyimg/static.official.source.yaml
+++ b/binaries/ttyimg/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tuiarchiver/static.official.source.yaml
+++ b/binaries/tuiarchiver/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tuiarchiver/static.official.source.yaml
+++ b/binaries/tuiarchiver/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tun2socks/static.official.source.yaml
+++ b/binaries/tun2socks/static.official.source.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tun2socks/static.official.source.yaml
+++ b/binaries/tun2socks/static.official.source.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/turbo-attack/static.official.source.yaml
+++ b/binaries/turbo-attack/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/turbo-attack/static.official.source.yaml
+++ b/binaries/turbo-attack/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/turbo-scanner/static.official.source.yaml
+++ b/binaries/turbo-scanner/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/turbo-scanner/static.official.source.yaml
+++ b/binaries/turbo-scanner/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tusd/static.official.source.yaml
+++ b/binaries/tusd/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tusd/static.official.source.yaml
+++ b/binaries/tusd/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tut/static.official.source.yaml
+++ b/binaries/tut/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tut/static.official.source.yaml
+++ b/binaries/tut/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/txeh/static.official.source.yaml
+++ b/binaries/txeh/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/txeh/static.official.source.yaml
+++ b/binaries/txeh/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tz/static.official.source.yaml
+++ b/binaries/tz/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/tz/static.official.source.yaml
+++ b/binaries/tz/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/u-root/static.official.source.yaml
+++ b/binaries/u-root/static.official.source.yaml
@@ -53,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/u-root/static.official.source.yaml
+++ b/binaries/u-root/static.official.source.yaml
@@ -33,6 +33,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -52,7 +53,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/udon/static.official.source.yaml
+++ b/binaries/udon/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/udon/static.official.source.yaml
+++ b/binaries/udon/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/udpx/static.official.source.yaml
+++ b/binaries/udpx/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/udpx/static.official.source.yaml
+++ b/binaries/udpx/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/udpz/static.official.source.yaml
+++ b/binaries/udpz/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/udpz/static.official.source.yaml
+++ b/binaries/udpz/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/uforall/static.official.source.yaml
+++ b/binaries/uforall/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/uforall/static.official.source.yaml
+++ b/binaries/uforall/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/umoci/static.official.source.yaml
+++ b/binaries/umoci/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/umoci/static.official.source.yaml
+++ b/binaries/umoci/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unch/static.official.source.yaml
+++ b/binaries/unch/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unch/static.official.source.yaml
+++ b/binaries/unch/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/uncover/static.official.stable.yaml
+++ b/binaries/uncover/static.official.stable.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/uncover/static.official.stable.yaml
+++ b/binaries/uncover/static.official.stable.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/undock/static.official.source.yaml
+++ b/binaries/undock/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/undock/static.official.source.yaml
+++ b/binaries/undock/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unew/static.official.source.yaml
+++ b/binaries/unew/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unew/static.official.source.yaml
+++ b/binaries/unew/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unfurl/static.official.source.yaml
+++ b/binaries/unfurl/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unfurl/static.official.source.yaml
+++ b/binaries/unfurl/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unix/static.rsc-v6unix.source.yaml
+++ b/binaries/unix/static.rsc-v6unix.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/unix/static.rsc-v6unix.source.yaml
+++ b/binaries/unix/static.rsc-v6unix.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/url-parser/static.official.source.yaml
+++ b/binaries/url-parser/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/url-parser/static.official.source.yaml
+++ b/binaries/url-parser/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/urlfinder/static.official.source.yaml
+++ b/binaries/urlfinder/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/urlfinder/static.official.source.yaml
+++ b/binaries/urlfinder/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/urlhunter/static.official.source.yaml
+++ b/binaries/urlhunter/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/urlhunter/static.official.source.yaml
+++ b/binaries/urlhunter/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/usql/static.glibc.source.yaml
+++ b/binaries/usql/static.glibc.source.yaml
@@ -68,7 +68,7 @@ x_exec:
        mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-D_LARGEFILE64_SOURCE -O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Deps

--- a/binaries/usql/static.glibc.source.yaml
+++ b/binaries/usql/static.glibc.source.yaml
@@ -47,6 +47,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -67,7 +68,7 @@ x_exec:
        mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-D_LARGEFILE64_SOURCE -O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Deps

--- a/binaries/usque/static.official.source.yaml
+++ b/binaries/usque/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/usque/static.official.source.yaml
+++ b/binaries/usque/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/validtoml/static.official.source.yaml
+++ b/binaries/validtoml/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/validtoml/static.official.source.yaml
+++ b/binaries/validtoml/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vegeta/static.official.stable.yaml
+++ b/binaries/vegeta/static.official.stable.yaml
@@ -59,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vegeta/static.official.stable.yaml
+++ b/binaries/vegeta/static.official.stable.yaml
@@ -39,6 +39,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -58,7 +59,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vermilion/static.official.source.yaml
+++ b/binaries/vermilion/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vermilion/static.official.source.yaml
+++ b/binaries/vermilion/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vfox/static.official.stable.yaml
+++ b/binaries/vfox/static.official.stable.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vfox/static.official.stable.yaml
+++ b/binaries/vfox/static.official.stable.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vhost-fuzzer/static.official.source.yaml
+++ b/binaries/vhost-fuzzer/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vhost-fuzzer/static.official.source.yaml
+++ b/binaries/vhost-fuzzer/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vhs/static.official.stable.yaml
+++ b/binaries/vhs/static.official.stable.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vhs/static.official.stable.yaml
+++ b/binaries/vhs/static.official.stable.yaml
@@ -45,6 +45,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -64,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vultr-cli/static.official.stable.yaml
+++ b/binaries/vultr-cli/static.official.stable.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/vultr-cli/static.official.stable.yaml
+++ b/binaries/vultr-cli/static.official.stable.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wadl-dumper/static.official.source.yaml
+++ b/binaries/wadl-dumper/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wadl-dumper/static.official.source.yaml
+++ b/binaries/wadl-dumper/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wait4x/static.official.source.yaml
+++ b/binaries/wait4x/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wait4x/static.official.source.yaml
+++ b/binaries/wait4x/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/walk/static.official.stable.yaml
+++ b/binaries/walk/static.official.stable.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/walk/static.official.stable.yaml
+++ b/binaries/walk/static.official.stable.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/warp-plus/static.official.source.yaml
+++ b/binaries/warp-plus/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/warp-plus/static.official.source.yaml
+++ b/binaries/warp-plus/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/waybackfetch/static.official.source.yaml
+++ b/binaries/waybackfetch/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/waybackfetch/static.official.source.yaml
+++ b/binaries/waybackfetch/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/waybackrobots/static.official.source.yaml
+++ b/binaries/waybackrobots/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/waybackrobots/static.official.source.yaml
+++ b/binaries/waybackrobots/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/waybackurls/static.official.source.yaml
+++ b/binaries/waybackurls/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/waybackurls/static.official.source.yaml
+++ b/binaries/waybackurls/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/web-cache-vulnerability-scanner/static.official.source.yaml
+++ b/binaries/web-cache-vulnerability-scanner/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/web-cache-vulnerability-scanner/static.official.source.yaml
+++ b/binaries/web-cache-vulnerability-scanner/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wego/static.official.source.yaml
+++ b/binaries/wego/static.official.source.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wego/static.official.source.yaml
+++ b/binaries/wego/static.official.source.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wgcf-cli/static.official.source.yaml
+++ b/binaries/wgcf-cli/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wgcf-cli/static.official.source.yaml
+++ b/binaries/wgcf-cli/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wgcf/static.official.source.yaml
+++ b/binaries/wgcf/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wgcf/static.official.source.yaml
+++ b/binaries/wgcf/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wgcfcat/static.official.source.yaml
+++ b/binaries/wgcfcat/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wgcfcat/static.official.source.yaml
+++ b/binaries/wgcfcat/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wharfie/static.official.source.yaml
+++ b/binaries/wharfie/static.official.source.yaml
@@ -34,6 +34,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -53,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wharfie/static.official.source.yaml
+++ b/binaries/wharfie/static.official.source.yaml
@@ -54,7 +54,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/whoiswatcher/static.official.source.yaml
+++ b/binaries/whoiswatcher/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/whoiswatcher/static.official.source.yaml
+++ b/binaries/whoiswatcher/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/whoxysubs/static.official.source.yaml
+++ b/binaries/whoxysubs/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/whoxysubs/static.official.source.yaml
+++ b/binaries/whoxysubs/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wireguard/static.go.source.yaml
+++ b/binaries/wireguard/static.go.source.yaml
@@ -68,7 +68,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wireguard/static.go.source.yaml
+++ b/binaries/wireguard/static.go.source.yaml
@@ -48,6 +48,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -67,7 +68,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wireproxy/static.official.stable.yaml
+++ b/binaries/wireproxy/static.official.stable.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wireproxy/static.official.stable.yaml
+++ b/binaries/wireproxy/static.official.stable.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wiretap/static.official.stable.yaml
+++ b/binaries/wiretap/static.official.stable.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wiretap/static.official.stable.yaml
+++ b/binaries/wiretap/static.official.stable.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/witness/static.official.source.yaml
+++ b/binaries/witness/static.official.source.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/witness/static.official.source.yaml
+++ b/binaries/witness/static.official.source.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wpjson-parser/static.official.source.yaml
+++ b/binaries/wpjson-parser/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wpjson-parser/static.official.source.yaml
+++ b/binaries/wpjson-parser/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wsl/static.official.source.yaml
+++ b/binaries/wsl/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wsl/static.official.source.yaml
+++ b/binaries/wsl/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wtf/static.official.stable.yaml
+++ b/binaries/wtf/static.official.stable.yaml
@@ -62,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wtf/static.official.stable.yaml
+++ b/binaries/wtf/static.official.stable.yaml
@@ -42,6 +42,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -61,7 +62,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wth/static.official.stable.yaml
+++ b/binaries/wth/static.official.stable.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wth/static.official.stable.yaml
+++ b/binaries/wth/static.official.stable.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wush/static.official.source.yaml
+++ b/binaries/wush/static.official.source.yaml
@@ -38,6 +38,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -57,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/wush/static.official.source.yaml
+++ b/binaries/wush/static.official.source.yaml
@@ -58,7 +58,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xq/static.official.stable.yaml
+++ b/binaries/xq/static.official.stable.yaml
@@ -46,6 +46,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -65,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xq/static.official.stable.yaml
+++ b/binaries/xq/static.official.stable.yaml
@@ -66,7 +66,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xray-knife/static.official.source.yaml
+++ b/binaries/xray-knife/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xray-knife/static.official.source.yaml
+++ b/binaries/xray-knife/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xsubfind3r/static.official.source.yaml
+++ b/binaries/xsubfind3r/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xsubfind3r/static.official.source.yaml
+++ b/binaries/xsubfind3r/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xtee/static.official.source.yaml
+++ b/binaries/xtee/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xtee/static.official.source.yaml
+++ b/binaries/xtee/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xurlfind3r/static.official.source.yaml
+++ b/binaries/xurlfind3r/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xurlfind3r/static.official.source.yaml
+++ b/binaries/xurlfind3r/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xurls/static.official.source.yaml
+++ b/binaries/xurls/static.official.source.yaml
@@ -57,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/xurls/static.official.source.yaml
+++ b/binaries/xurls/static.official.source.yaml
@@ -37,6 +37,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -56,7 +57,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yalis/static.official.source.yaml
+++ b/binaries/yalis/static.official.source.yaml
@@ -46,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yalis/static.official.source.yaml
+++ b/binaries/yalis/static.official.source.yaml
@@ -26,6 +26,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -45,7 +46,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yataf/static.official.stable.yaml
+++ b/binaries/yataf/static.official.stable.yaml
@@ -28,6 +28,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -47,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yataf/static.official.stable.yaml
+++ b/binaries/yataf/static.official.stable.yaml
@@ -48,7 +48,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yggdrasil/static.official.source.yaml
+++ b/binaries/yggdrasil/static.official.source.yaml
@@ -49,6 +49,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -68,7 +69,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yggdrasil/static.official.source.yaml
+++ b/binaries/yggdrasil/static.official.source.yaml
@@ -69,7 +69,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yip/static.official.source.yaml
+++ b/binaries/yip/static.official.source.yaml
@@ -49,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yip/static.official.source.yaml
+++ b/binaries/yip/static.official.source.yaml
@@ -29,6 +29,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -48,7 +49,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yj/static.official.source.yaml
+++ b/binaries/yj/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yj/static.official.source.yaml
+++ b/binaries/yj/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yq/static.official.source.yaml
+++ b/binaries/yq/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/yq/static.official.source.yaml
+++ b/binaries/yq/static.official.source.yaml
@@ -65,7 +65,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zdns/static.official.source.yaml
+++ b/binaries/zdns/static.official.source.yaml
@@ -35,6 +35,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -54,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zdns/static.official.source.yaml
+++ b/binaries/zdns/static.official.source.yaml
@@ -55,7 +55,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zfind/static.official.stable.yaml
+++ b/binaries/zfind/static.official.stable.yaml
@@ -60,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zfind/static.official.stable.yaml
+++ b/binaries/zfind/static.official.stable.yaml
@@ -40,6 +40,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -59,7 +60,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1" 
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zfxtop/static.official.source.yaml
+++ b/binaries/zfxtop/static.official.source.yaml
@@ -36,6 +36,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -55,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zfxtop/static.official.source.yaml
+++ b/binaries/zfxtop/static.official.source.yaml
@@ -56,7 +56,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zgrab2/static.official.source.yaml
+++ b/binaries/zgrab2/static.official.source.yaml
@@ -52,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zgrab2/static.official.source.yaml
+++ b/binaries/zgrab2/static.official.source.yaml
@@ -32,6 +32,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -51,7 +52,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zombie/static.official.source.yaml
+++ b/binaries/zombie/static.official.source.yaml
@@ -31,6 +31,7 @@ x_exec:
   bsys: "docker://go"
   host:
     - "aarch64-Linux"
+    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
@@ -50,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build

--- a/binaries/zombie/static.official.source.yaml
+++ b/binaries/zombie/static.official.source.yaml
@@ -51,7 +51,7 @@ x_exec:
        set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
        CGO_ENABLED="1"
        CGO_CFLAGS="-O2 -flto=auto -fPIE -fpie -static -w -pipe"
-       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/;s/riscv64/riscv64/")"
+       GOARCH="$(uname -m | sed "s/x86_64/amd64/;s/aarch64/arm64/;s/loongarch64/loong64/")"
        GOOS="linux"
        export CGO_ENABLED CGO_CFLAGS GOARCH GOOS
       #Build


### PR DESCRIPTION
This PR introduces a set of packages for the RISC-V (riscv64) architecture, focusing primarily on source-based builds.

- Most additions are Go-based packages, which benefit from Go’s upstream RISC-V support.
- Most of the packages are **non** ppkg, nixpkgs.
- Mostly are source build packages.

I've tried to test few out of these locally and on native RISC-V as well, works perfectly fine as go is already supported on RISC-V. 

Please review PR and let me know if you require any additional testing from myside. 

tagging #198 