### PR TITLE
Fix starship builds

### DIFF
--- a/binaries/starship/static.official.stable.yaml
+++ b/binaries/starship/static.official.stable.yaml
@@ -55,10 +55,10 @@ x_exec:
     #Download
     case "$(uname -m)" in
       aarch64)
-        soar dl "https://github.com/starship/starship@${PKGVER}" --match "linux,aarch64,musl,tar" --exclude "amd64,x86,x64,sha256,sha512,bsd,macos,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
+        soar dl "https://github.com/starship/starship@${PKGVER}" --match "linux,aarch64,musl,tar" --exclude "amd64,x86,x64,sha256,sha512,bsd,macos,apple,darwin,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
         ;;
       x86_64)
-        soar dl "https://github.com/starship/starship@${PKGVER}" --match "linux,x86_64,musl,tar" --exclude "aarch,arm,i386,i686,sha256,sha512,bsd,macos,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
+        soar dl "https://github.com/starship/starship@${PKGVER}" --match "linux,x86_64,musl,tar" --exclude "aarch,arm,i386,i686,sha256,sha512,bsd,macos,apple,darwin,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
         ;;
     esac
     #Extract
@@ -73,4 +73,4 @@ x_exec:
        } || break
      done
     #Copy
-    find "${SBUILD_TMPDIR}" -maxdepth 1 -type f -exec file -i "{}" \; | grep -Ei "application/.*executable|inode/symlink|text/x-perl|text/.*script" | cut -d":" -f1 | xargs realpath --no-symlinks | xargs -I "{}" rsync -achvL "{}" "${SBUILD_OUTDIR}/${PKG}"
+    find "${SBUILD_TMPDIR}" -maxdepth 1 -type f -exec file -i "{}" \; | grep -Ei "application/.*executable|inode/symlink|text/x-perl|text/.*script" | cut -d":" -f1 | xargs -I "{}" realpath --no-symlinks "{}" | xargs -I "{}" rsync -achvL "{}" "${SBUILD_OUTDIR}/${PKG}"


### PR DESCRIPTION
builds were failing on amd64 hosts due to xargs realpath missing it's operand with the following error:

```
realpath: missing operand
```

The fix for this is relatively simple, add `-I "{}"` back in to the xargs options, and then add `"{}"` to the realpath.

Further, the aarch64 builds were failing because it was downloading file `starship-aarch64-apple-darwin.tar.gz`. Macos was listed in the ignored file names list, but that's not in the name and apple and darwin were still allowed, so I've added them to the ignore list.