### PR TITLE
Use prebuilt binaries for fish

### DIFF
--- a/binaries/fish/static.official.source.yaml
+++ b/binaries/fish/static.official.source.yaml
@@ -3,7 +3,7 @@
 _disabled: false
 
 pkg: "fish"
-pkg_id: "github.com.fish-shell.fish-shell.source"
+pkg_id: "github.com.fish-shell.fish-shell"
 pkg_type: "static"
 category:
   - "ConsoleOnly"
@@ -40,8 +40,6 @@ note:
   - "Built From Source (Latest Git HEAD). Check/Report @ https://github.com/fish-shell/fish-shell"
 provides:
   - "fish"
-  - "fish_indent"
-  - "fish_key_reader"
 repology:
   - "fish"
 src_url:
@@ -49,85 +47,33 @@ src_url:
 tag:
   - "Utility"
 x_exec:
-  bsys: "docker://rust"
+  bsys: "host://soar-dl"
   host:
     - "aarch64-Linux"
-    - "riscv64-Linux"
     - "x86_64-Linux"
   shell: "bash"
   pkgver: |
-    pushd "$(mktemp -d)" &>/dev/null && \
-    git clone --depth="1" --filter="blob:none" --no-checkout --single-branch --quiet "https://github.com/fish-shell/fish-shell" "./TEMPREPO" &>/dev/null && \
-    git --git-dir="./TEMPREPO/.git" --no-pager log -1 --pretty=format:'HEAD-%h-%cd' --date=format:'%y%m%dT%H%M%S' && \
-    [ -d "$(realpath .)/TEMPREPO" ] && rm -rf "$(realpath .)" &>/dev/null && popd &>/dev/null
+    curl -qfsSL "https://api.gh.pkgforge.dev/repos/fish-shell/fish-shell/releases?per_page=100" | jq -r '[.[] | select(.draft == false)] | .[0].tag_name | gsub("\\s+"; "")' | tr -d '"'\''[:space:]'
   run: |
-    #Build
-     mkdir -pv "${SBUILD_TMPDIR}/tmp" && docker run --privileged --net="host" --name "alpine-builder" --pull="always" \
-     -e "PKG=${PKG}" -e "PKG_ID=${PKG_ID}" -e "PKG_TYPE=${PKG_TYPE}" -e "PKG_VER=${PKG_VER}" \
-     -e "PKGVER=${PKGVER}" -e "SBUILD_PKG=${SBUILD_PKG}" -e "SBUILD_PKGVER=${SBUILD_PKGVER}" \
-     --volume "${SBUILD_TMPDIR}/tmp:/tmp:rw" \
-     "ghcr.io/pkgforge/devscripts/alpine-builder:$(uname -m)" \
-      bash -l -c '
-      #Setup ENV
-       set -x ; mkdir -p "/build-bins" && pushd "$(mktemp -d)" &>/dev/null
-       [[ -s "${HOME}/.cargo/env" ]] && source "${HOME}/.cargo/env"
-       if [[ "$(uname -m | tr -d '[:space:]')" == "riscv64" ]]; then
-         RUST_TARGET="$(rustc -Vv 2>/dev/null | sed -n "s/^[[:space:]]*host[[:space:]]*:[[:space:]]*//p" | grep -i "riscv" | tr -d "[:space:]")"
-         if [[ -n "${RUST_TARGET//[[:space:]]/}" ]]; then
-           export RUST_TARGET
-         else
-           rustc -Vv ; exit 1
-         fi
-       else
-         rustup default nightly
-         rustup component add rust-src --toolchain nightly
-         export RUST_TARGET="$(uname -m)-unknown-linux-musl"
-         rustup target add "${RUST_TARGET}"
-       fi
-       RUST_FLAGS=()
-       RUST_FLAGS+=("-C target-feature=+crt-static")
-       RUST_FLAGS+=("-C default-linker-libraries=yes")
-       if echo "${RUST_TARGET}" | grep -Eqiv "alpine|gnu"; then
-         RUST_FLAGS+=("-C link-self-contained=yes")
-       fi
-       RUST_FLAGS+=("-C prefer-dynamic=no")
-       RUST_FLAGS+=("-C embed-bitcode=yes")
-       RUST_FLAGS+=("-C lto=yes")
-       RUST_FLAGS+=("-C opt-level=z")
-       RUST_FLAGS+=("-C debuginfo=none")
-       RUST_FLAGS+=("-C strip=symbols")
-       RUST_FLAGS+=("-C linker=clang")
-       RUST_FLAGS+=("-C link-arg=-fuse-ld=$(which mold)")
-       RUST_FLAGS+=("-C link-arg=-Wl,--Bstatic")
-       RUST_FLAGS+=("-C link-arg=-Wl,--static")
-       RUST_FLAGS+=("-C link-arg=-Wl,-S")
-       RUST_FLAGS+=("-C link-arg=-Wl,--build-id=none")
-       export RUSTFLAGS="${RUST_FLAGS[*]}"
-      #Build
-       git clone --filter "blob:none" --quiet "https://github.com/fish-shell/fish-shell" "./TEMPREPO" && cd "./TEMPREPO/"
-       echo -e "\n[+] Target: ${RUST_TARGET}"
-       echo -e "[+] Flags: ${RUSTFLAGS}\n"
-       sed "/^\[profile\.release\]/,/^$/d" -i "./Cargo.toml" ; echo -e "\n[profile.release]\nstrip = true\nopt-level = 3\nlto = true" >> "./Cargo.toml"
-       rm -rvf "./.cargo" rust-toolchain* 2>/dev/null
-       cargo build --workspace --target "${RUST_TARGET}" \
-         --all-features \
-         --jobs="$(($(nproc)+1))" \
-         --release \
-         --keep-going \
-         --verbose
-       find -L "./target/${RUST_TARGET}/release" -maxdepth 1 -type f 2>/dev/null
-      #Copy
-       find "./target/${RUST_TARGET}/release" -maxdepth 1 -type f -exec file -i "{}" \; | grep -Ei "application/.*executable|inode/symlink|text/x-perl|text/.*script" | cut -d":" -f1 | xargs realpath --no-symlinks | xargs -I "{}" rsync -achvL "{}" "/build-bins/"
-       ( askalono --format "json" crawl --follow "$(realpath .)" | jq -r ".. | objects | .path? // empty" | head -n 1 | xargs -I "{}" cp -fv "{}" "/build-bins/LICENSE" ) 2>/dev/null
-      #Strip 
-       find "/build-bins/" -type f -exec objcopy --remove-section=".comment" --remove-section=".note.*" "{}" \;
-       find "/build-bins/" -type f ! -name "*.no_strip" -exec strip --strip-all --verbose "{}" 2>/dev/null \;
-       find "/build-bins/" -type f -exec bash -c "echo && realpath {} && readelf --section-headers {} 2>/dev/null" \;
-       file "/build-bins/"* && stat -c "%n:         %s Bytes" "/build-bins/"* && \
-       du "/build-bins/"* --bytes --human-readable --time --time-style="full-iso" --summarize
-       popd &>/dev/null
-      '
-    #Copy & Meta
-     docker cp "alpine-builder:/build-bins/." "${SBUILD_TMPDIR}/"
-     [ -s "${SBUILD_TMPDIR}/LICENSE" ] && cp -fv "${SBUILD_TMPDIR}/LICENSE" "${SBUILD_OUTDIR}/LICENSE"
-     find "${SBUILD_TMPDIR}" -maxdepth 1 -type f -exec file -i "{}" \; | grep -Ei "application/.*executable|inode/symlink|text/x-perl|text/.*script" | cut -d":" -f1 | xargs realpath --no-symlinks | xargs -I "{}" rsync -achvL "{}" "${SBUILD_OUTDIR}"
+    #Download
+    case "$(uname -m)" in
+      aarch64)
+        soar dl "https://github.com/fish-shell/fish-shell@${PKGVER}" --match "linux,aarch64,musl,tar" --exclude "amd64,x86,x64,sha256,sha512,bsd,macos,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
+        ;;
+      x86_64)
+        soar dl "https://github.com/fish-shell/fish-shell@${PKGVER}" --match "linux,x86_64,musl,tar" --exclude "aarch,arm,i386,i686,sha256,sha512,bsd,macos,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
+        ;;
+    esac
+    #Extract
+    while E_X=$(find "${SBUILD_TMPDIR}" -type f -exec file -i "{}" + |
+     grep -Ei "archive|compressed|gzip|x-compress|x-tar" |
+     grep -iv "application/.*executable" |
+     cut -d: -f1 | head -n1); [ -n "${E_X}" ]
+     do
+       7z e "${E_X}" -o"${SBUILD_TMPDIR}/." -y && {
+        file -i "${E_X}" | grep -q "application/.*executable" && break
+        rm -f "${E_X}"
+       } || break
+     done
+    #Copy
+    find "${SBUILD_TMPDIR}" -maxdepth 1 -type f -exec file -i "{}" \; | grep -Ei "application/.*executable|inode/symlink|text/x-perl|text/.*script" | cut -d":" -f1 | xargs realpath --no-symlinks | xargs -I "{}" rsync -achvL "{}" "${SBUILD_OUTDIR}/${PKG}"


### PR DESCRIPTION
The existing fish script was not building correctly so it had never produced a fish binary based on the upstream. As fish provides pre-build binaries, it would be much better to just use those. I have switched from building from source to downloading, using a very similar method to starship (as I've just worked on a PR for that, see #228).

Here's a copy of the build output:

```
$ sbuild build ./static.official.source.yaml --keep --outdir ./SBUILD-TEST
sbuild v0.1.10
 INFO Building: ./static.official.source.yaml
Linting ./static.official.source.yaml (/home/matthew/gits/soarpkgs/binaries/fish/./static.official.source.yaml)

Performing shellcheck
[✔] Shellcheck passed
[✔] Fetched version (4.3.2) using x_exec.pkgver written to ./static.official.source.yaml.pkgver
SBUILD validation successful.
Validated YAML has been written to ./static.official.source.yaml.validated
_disabled: false

pkg: "fish"
pkg_id: "github.com.fish-shell.fish-shell"
pkg_type: "static"
category:
  - "ConsoleOnly"
  - "Utility"
description: "Smart and User-friendly Command Line Shell"
distro_pkg:
  alpine:
    - "fish"
  archlinux:
    aur:
      - "fish-git"
    extra:
      - "fish"
  debian:
    - "fish"
  gnuguix:
    - "fish"
  homebrew:
    - "fish"
  nixpkgs:
    - "fish"
    - "fishMinimal"
  stalix:
    - "bin/fish"
homepage:
  - "https://github.com/fish-shell/fish-shell"
maintainer:
  - "Azathothas (https://github.com/Azathothas)"
license:
  - id: "Custom"
    url: "https://github.com/fish-shell/fish-shell/raw/8617964d4dbf03d752fbf094600ef977a36a83ec/COPYING"
note:
  - "[DO NOT RUN] (Meant for pkgforge CI Only)"
  - "Built From Source (Latest Git HEAD). Check/Report @ https://github.com/fish-shell/fish-shell"
provides:
  - "fish"
repology:
  - "fish"
src_url:
  - "https://github.com/fish-shell/fish-shell"
tag:
  - "Utility"
x_exec:
  host:
    - "aarch64-linux"
    - "x86_64-linux"
  shell: "bash"
  pkgver: |
    curl -qfsSL "https://api.gh.pkgforge.dev/repos/fish-shell/fish-shell/releases?per_page=100" | jq -r '[.[] | select(.draft == false)] | .[0].tag_name | gsub("\\s+"; "")' | tr -d '"'\''[:space:]'
  run: |
    #Download
    case "$(uname -m)" in
      aarch64)
        soar dl "https://github.com/fish-shell/fish-shell@${PKGVER}" --match "linux,aarch64,musl,tar" --exclude "amd64,x86,x64,sha256,sha512,bsd,macos,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
        ;;
      x86_64)
        soar dl "https://github.com/fish-shell/fish-shell@${PKGVER}" --match "linux,x86_64,musl,tar" --exclude "aarch,arm,i386,i686,sha256,sha512,bsd,macos,windows" -o "${SBUILD_TMPDIR}/${PKG}.archive" --yes
        ;;
    esac
    #Extract
    while E_X=$(find "${SBUILD_TMPDIR}" -type f -exec file -i "{}" + |
     grep -Ei "archive|compressed|gzip|x-compress|x-tar" |
     grep -iv "application/.*executable" |
     cut -d: -f1 | head -n1); [ -n "${E_X}" ]
     do
       7z e "${E_X}" -o"${SBUILD_TMPDIR}/." -y && {
        file -i "${E_X}" | grep -q "application/.*executable" && break
        rm -f "${E_X}"
       } || break
     done
    #Copy
    find "${SBUILD_TMPDIR}" -maxdepth 1 -type f -exec file -i "{}" \; | grep -Ei "application/.*executable|inode/symlink|text/x-perl|text/.*script" | cut -d":" -f1 | xargs realpath --no-symlinks | xargs -I "{}" rsync -achvL "{}" "${SBUILD_OUTDIR}/${PKG}"

Downloading license from https://github.com/fish-shell/fish-shell/raw/8617964d4dbf03d752fbf094600ef977a36a83ec/COPYING to LICENSE
Detected GitHub URL, processing as GitHub release
Found release: 4.3.2
Downloading asset: fish-4.3.2-linux-aarch64.tar.xz

7-Zip (z) 25.01 (arm64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03
 64-bit arm_v:8-A locale=C.UTF-8 Threads:4 OPEN_MAX:1024, ASM

Scanning the drive for archives:
1 file, 2824572 bytes (2759 KiB)

Extracting archive: /home/matthew/gits/soarpkgs/binaries/fish/./SBUILD-TEST/github.com.fish-shell.fish-shell/SBUILD_TEMP/fish.archive
--
Path = /home/matthew/gits/soarpkgs/binaries/fish/./SBUILD-TEST/github.com.fish-shell.fish-shell/SBUILD_TEMP/fish.archive
Type = xz
Physical Size = 2824572
Method = LZMA2:23 CRC64
Streams = 1
Blocks = 1

Everything is Ok

Size:       14213120
Compressed: 2824572

7-Zip (z) 25.01 (arm64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03
 64-bit arm_v:8-A locale=C.UTF-8 Threads:4 OPEN_MAX:1024, ASM

Scanning the drive for archives:
1 file, 14213120 bytes (14 MiB)

Extracting archive: /home/matthew/gits/soarpkgs/binaries/fish/./SBUILD-TEST/github.com.fish-shell.fish-shell/SBUILD_TEMP/fish
--
Path = /home/matthew/gits/soarpkgs/binaries/fish/./SBUILD-TEST/github.com.fish-shell.fish-shell/SBUILD_TEMP/fish
Type = tar
Physical Size = 14213120
Headers Size = 7680
Code Page = UTF-8
Characteristics = GNU ASCII

Everything is Ok

Size:       14205264
Compressed: 14213120
sending incremental file list
fish

sent 14.21M bytes  received 35 bytes  28.42M bytes/sec
total size is 14.21M  speedup is 1.00
[✔] Successfully built the package at /home/matthew/gits/soarpkgs/binaries/fish/./SBUILD-TEST/github.com.fish-shell.fish-shell
 INFO Generating checksums...
 INFO Checksums generated

[+] 1 of 1 packages built successfully
[⏱] Completed in 2.85s
```