### PR TITLE
fix: use pkg_id from recipe for cache operations

### DIFF
--- a/.github/workflows/build-on-change.yaml
+++ b/.github/workflows/build-on-change.yaml
@@ -117,7 +117,18 @@ jobs:
 
           echo "$CHANGED_RECIPES" | jq -c '.[]' | while read -r recipe; do
             path=$(echo "$recipe" | jq -r '.path')
-            pkg_name=$(basename "$(dirname "$path")")
+
+            # Extract pkg_id from recipe YAML for cache lookups
+            pkg_id=""
+            pkg_name=""
+            if [ -f "$path" ]; then
+              pkg_id=$(grep -E '^pkg_id:' "$path" | head -1 | sed 's/pkg_id:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+              pkg_name=$(grep -E '^pkg:' "$path" | head -1 | sed 's/pkg:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+            fi
+            # Fallback to pkg name from recipe
+            if [ -z "$pkg_id" ]; then
+              pkg_id="${pkg_name:-$(basename "$(dirname "$path")")}"
+            fi
 
             # Skip cache check if force rebuild
             if [ "$FORCE_REBUILD" == "true" ]; then
@@ -134,12 +145,12 @@ jobs:
 
             # Check if already built with same hash
             if [ -f "/tmp/build_cache.sdb" ] && command -v sbuild-cache &>/dev/null; then
-              cached_info=$(sbuild-cache --cache /tmp/build_cache.sdb get --package "$pkg_name" --json 2>/dev/null || echo "")
+              cached_info=$(sbuild-cache --cache /tmp/build_cache.sdb get --package "$pkg_id" --json 2>/dev/null || echo "")
               cached_hash=$(echo "$cached_info" | jq -r '.recipe_hash // ""' 2>/dev/null || echo "")
               cached_status=$(echo "$cached_info" | jq -r '.last_build_status // ""' 2>/dev/null || echo "")
 
               if [ "$cached_hash" == "$current_hash" ] && [ "$cached_status" == "success" ]; then
-                echo "::notice::Skipping $pkg_name - already built with same hash" >&2
+                echo "::notice::Skipping $pkg_id - already built with same hash" >&2
                 continue
               fi
             fi
@@ -219,8 +230,17 @@ jobs:
           echo "$RECIPES" | jq -c '.[]' | while read -r recipe; do
             path=$(echo "$recipe" | jq -r '.path')
 
-            # Extract package name from path (e.g., binaries/hello/static.yaml -> hello)
-            pkg_name=$(basename "$(dirname "$path")")
+            # Extract pkg_id and pkg name from recipe YAML for cache operations
+            pkg_id=""
+            pkg_name=""
+            if [ -f "$path" ]; then
+              pkg_id=$(grep -E '^pkg_id:' "$path" | head -1 | sed 's/pkg_id:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+              pkg_name=$(grep -E '^pkg:' "$path" | head -1 | sed 's/pkg:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+            fi
+            # Fallback to pkg name from recipe
+            if [ -z "$pkg_id" ]; then
+              pkg_id="${pkg_name:-$(basename "$(dirname "$path")")}"
+            fi
 
             # Extract version from recipe's pkgver field
             pkg_version=""
@@ -230,7 +250,7 @@ jobs:
 
             # Skip if we have no version
             if [ -z "$pkg_version" ]; then
-              echo "Skipping $pkg_name: no version available"
+              echo "Skipping $pkg_id: no version available"
               continue
             fi
 
@@ -270,14 +290,14 @@ jobs:
                 continue
               fi
 
-              echo "Package: $pkg_name ($host), Version: $pkg_version, Status: $status"
+              echo "Package: $pkg_id ($host), Version: $pkg_version, Status: $status"
 
               sbuild-cache --cache /tmp/build_cache.sdb update \
-                --package "$pkg_name" \
+                --package "$pkg_id" \
                 --host "$host" \
                 --version "$pkg_version" \
                 --hash "$recipe_hash" \
-                --status "$status" || echo "Warning: Failed to update cache for $pkg_name ($host)"
+                --status "$status" || echo "Warning: Failed to update cache for $pkg_id ($host)"
             done
           done
 

--- a/.github/workflows/pr-build-test.yaml
+++ b/.github/workflows/pr-build-test.yaml
@@ -143,20 +143,36 @@ jobs:
 
           echo "$RECIPES" | jq -c '.[]' | while read -r recipe; do
             path=$(echo "$recipe" | jq -r '.path')
-            pkg_name=$(basename "$(dirname "$path")")
+
+            # Extract pkg_id from recipe YAML for cache operations
+            pkg_id=""
+            pkg_name=""
+            if [ -f "$path" ]; then
+              pkg_id=$(grep -E '^pkg_id:' "$path" | head -1 | sed 's/pkg_id:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+              pkg_name=$(grep -E '^pkg:' "$path" | head -1 | sed 's/pkg:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+            fi
+            # Fallback to pkg field then directory name
+            if [ -z "$pkg_id" ]; then
+              pkg_id="${pkg_name:-$(basename "$(dirname "$path")")}"
+            fi
 
             # Extract version from recipe's pkgver field
-            pkg_version="unknown"
+            pkg_version=""
             if [ -f "$path" ]; then
-              pkg_version=$(grep -E "^pkgver:" "$path" | head -1 | sed 's/pkgver:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//' || echo "unknown")
-              [ -z "$pkg_version" ] && pkg_version="unknown"
+              pkg_version=$(grep -E "^pkgver:" "$path" | head -1 | sed 's/pkgver:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+            fi
+
+            # Skip if we have no version
+            if [ -z "$pkg_version" ]; then
+              echo "Skipping $pkg_id: no version available"
+              continue
             fi
 
             # Compute recipe hash (excluding version for consistency)
             if [ -f "$path" ]; then
               recipe_hash=$(sbuild-linter hash --exclude-version "$path" 2>/dev/null || sha256sum "$path" | cut -d' ' -f1)
             else
-              recipe_hash="unknown"
+              recipe_hash=""
             fi
 
             status="success"
@@ -164,10 +180,10 @@ jobs:
               status="failure"
             fi
 
-            echo "Caching: $pkg_name v${pkg_version} (hash: ${recipe_hash:0:16}..., status: $status)"
+            echo "Caching: $pkg_id v${pkg_version} (hash: ${recipe_hash:0:16}..., status: $status)"
 
             sbuild-cache --cache /tmp/build_cache.sdb update \
-              --package "$pkg_name" \
+              --package "$pkg_id" \
               --version "$pkg_version" \
               --hash "$recipe_hash" \
               --status "$status" || true

--- a/.github/workflows/rolling-rebuilds.yaml
+++ b/.github/workflows/rolling-rebuilds.yaml
@@ -343,8 +343,17 @@ jobs:
             path=$(echo "$pkg" | jq -r '.path')
             new_version=$(echo "$pkg" | jq -r '.new_version // ""')
 
-            # Extract package name from path
-            pkg_name=$(basename "$(dirname "$path")")
+            # Extract pkg_id and pkg name from recipe YAML for cache operations
+            pkg_id=""
+            pkg_name=""
+            if [ -f "$path" ]; then
+              pkg_id=$(grep -E '^pkg_id:' "$path" | head -1 | sed 's/pkg_id:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+              pkg_name=$(grep -E '^pkg:' "$path" | head -1 | sed 's/pkg:[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//')
+            fi
+            # Fallback to pkg name from recipe
+            if [ -z "$pkg_id" ]; then
+              pkg_id="${pkg_name:-$(basename "$(dirname "$path")")}"
+            fi
 
             # Use version from pkgver output or fall back to recipe
             pkg_version="$new_version"
@@ -396,14 +405,14 @@ jobs:
                 continue
               fi
 
-              echo "Package: $pkg_name ($host), Version: $pkg_version, Status: $status"
+              echo "Package: $pkg_id ($host), Version: $pkg_version, Status: $status"
 
               sbuild-cache --cache /tmp/build_cache.sdb update \
-                --package "$pkg_name" \
+                --package "$pkg_id" \
                 --host "$host" \
                 --version "$pkg_version" \
                 --hash "$recipe_hash" \
-                --status "$status" || echo "Warning: Failed to update cache for $pkg_name ($host)"
+                --status "$status" || echo "Warning: Failed to update cache for $pkg_id ($host)"
             done
           done
 


### PR DESCRIPTION
Workflows were using directory name as package identifier for sbuild-cache get/update calls, which is ambiguous when multiple packages share the same directory (e.g., coreutils). Now extracts pkg_id from the recipe YAML, falling back to pkg name then directory.

Also removes "unknown" default values from pr-build-test cache updates.