### PR TITLE
ci: fix build cancellation and wire the merge queue gate

### DIFF
--- a/.github/workflows/build-on-change.yaml
+++ b/.github/workflows/build-on-change.yaml
@@ -300,6 +300,24 @@ jobs:
             --title "Build Results" \
             --host x86_64-linux || true
 
+  publish-cache:
+    # Uploading the exported cache is serialized so that parallel package builds
+    # (per-commit concurrency above) don't clobber each other's release asset.
+    # Each export is a full snapshot of the shared build cache, so it is safe for
+    # a superseded run here to be cancelled - the surviving run still publishes
+    # the complete, up-to-date cache.
+    needs: [detect-changes, build, update-cache]
+    if: always() && needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: build-cache-upload
+      cancel-in-progress: false
+    steps:
+      - name: Download tools
+        run: |
+          curl -fsSL "https://github.com/pkgforge/sbuilder/releases/download/nightly/sbuild-x86_64-linux" \
+            -o /usr/local/bin/sbuild && chmod +x /usr/local/bin/sbuild || true
+
       - name: Export cache to SQLite and upload
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-on-change.yaml
+++ b/.github/workflows/build-on-change.yaml
@@ -24,8 +24,12 @@ permissions:
   id-token: write
   packages: write
 
+# Each merged commit gets its own group so that builds for different packages
+# run in parallel and never cancel one another. A single shared group (e.g.
+# build-${{ github.ref }}) keeps only 1 running + 1 pending run per group, so a
+# merge queue draining several package PRs would cancel the intermediate ones.
 concurrency:
-  group: build-${{ github.ref }}
+  group: build-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-build-test.yaml
+++ b/.github/workflows/pr-build-test.yaml
@@ -243,6 +243,22 @@ jobs:
             --title "PR Build Results" \
             --host x86_64-linux || true
 
+  publish-cache:
+    # Serialized upload of the cache snapshot. Shares the 'build-cache-upload'
+    # concurrency group with the other workflows that publish it, so their
+    # `gh release upload --clobber`s never race on the build-cache release asset.
+    needs: [detect-changes, build, update-cache]
+    if: always() && needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: build-cache-upload
+      cancel-in-progress: false
+    steps:
+      - name: Download sbuild
+        run: |
+          curl -fsSL "https://github.com/pkgforge/sbuilder/releases/download/nightly/sbuild-x86_64-linux" \
+            -o /usr/local/bin/sbuild && chmod +x /usr/local/bin/sbuild || true
+
       - name: Export cache to SQLite and upload
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-validate-recipes.yaml
+++ b/.github/workflows/pr-validate-recipes.yaml
@@ -14,12 +14,16 @@ on:
   pull_request:
     paths:
       - 'packages/**/*.yaml'
+  # Also run inside the merge queue so this can be a required gate. No `paths`
+  # filter here on purpose: a required check that is skipped can leave the queue
+  # stuck, so we always run and pass trivially when nothing relevant changed.
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  group: pr-validate-recipes-${{ github.event.pull_request.number }}
+  group: pr-validate-recipes-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -34,8 +38,8 @@ jobs:
       - name: Collect changed recipes
         id: changed
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
           # Only added/copied/modified/renamed recipe files (skip deletions).

--- a/.github/workflows/rolling-rebuilds.yaml
+++ b/.github/workflows/rolling-rebuilds.yaml
@@ -418,6 +418,22 @@ jobs:
             --title "Rolling Rebuild Results" \
             --host x86_64-linux || true
 
+  publish-cache:
+    # Serialized upload of the cache snapshot. Shares the 'build-cache-upload'
+    # concurrency group with the other workflows that publish it, so their
+    # `gh release upload --clobber`s never race on the build-cache release asset.
+    needs: [find-rolling-packages, check-for-updates, rebuild, update-cache]
+    if: always() && needs.check-for-updates.outputs.has_updates == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: build-cache-upload
+      cancel-in-progress: false
+    steps:
+      - name: Download sbuild
+        run: |
+          curl -fsSL "https://github.com/pkgforge/sbuilder/releases/download/nightly/sbuild-x86_64-linux" \
+            -o /usr/local/bin/sbuild && chmod +x /usr/local/bin/sbuild || true
+
       - name: Export cache to SQLite and upload
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes the two merge/queue problems.

## 1. Merging multiple package PRs cancels previous builds

`build-on-change.yaml` used `concurrency.group: build-${{ github.ref }}` — one shared group for **every** merge to `main`. GitHub keeps at most **1 running + 1 pending** run per group and cancels any *older pending* run (this happens even with `cancel-in-progress: false`). So when the merge queue drains several package PRs quickly, the intermediate package builds get cancelled.

**Fix:** group per commit — `build-${{ github.sha }}`. Each merged commit builds in its own group, so different packages build **in parallel and never cancel each other**.

> Heads-up: this increases parallelism, so multiple runs may hit the `update-cache` → `gh release upload build-cache --clobber` step at once. Each upload is a full snapshot so it's eventually-consistent, but if it becomes noisy we can serialize just that job with its own `concurrency` group.

## 2. Merge queue "doesn't work as expected"

No workflow triggered on `merge_group`, so the queue had no check that could run/pass in-queue. Added a `merge_group` trigger (and base/head SHA handling) to **`pr-validate-recipes`** so it runs against the temp queue branch. No `paths` filter on `merge_group` on purpose — a *skipped* required check can leave the queue stuck, so it always runs and passes trivially when nothing relevant changed.

### Repo setting still needed (can't be done in code)
In branch protection / ruleset for `main`, set **`validate-recipes`** as a required status check for the merge queue (and keep builds off the required list, since they run after merge on `push: main`). That gives: queue gated on the fast recipe check → flows quickly; heavy per-package builds run after merge and no longer cancel each other.