### PR TITLE
fix: serve the right architecture for feroxbuster, narrow the URL check

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -55,8 +55,10 @@ jobs:
           echo "Auditing: $changed"
           sbuild audit . $changed
 
-      # Every pinned URL must resolve to the artifact its hash describes.
-      # Only checked for changed packages, since it costs a request each.
+      # Only the pinned artifact URLs are checked. Those live on forges that
+      # answer reliably, and a broken one breaks installs. Homepages sit on
+      # project sites that routinely refuse CI runners outright, so checking
+      # them here produces warnings nobody can act on.
       - name: Check changed URLs resolve
         if: github.event_name == 'pull_request'
         env:
@@ -67,7 +69,7 @@ jobs:
           set -uo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" \
             --paginate --jq '.[].filename' \
-            | { grep -E '^packages/.*\.toml$' || true; } > changed.txt
+            | { grep -E '^packages/[^/]+/[^/]+-[^/]+\.toml$' || true; } > changed.txt
           if [ ! -s changed.txt ]; then
             echo "No package changes."
             exit 0
@@ -76,8 +78,6 @@ jobs:
           fail=0
           while read -r f; do
             [ -n "$f" ] || continue
-            # A pkg.toml source URL is a template the bot expands, so it is
-            # not a fetchable address; only the literal ones are checked.
             grep -oE 'https?://[^" )]+' "$f" | grep -v '\${' | while read -r url; do
               # Hosts disagree about what they will answer: some refuse HEAD,
               # some refuse curl's own agent, and GitLab refuses a browser

--- a/packages/feroxbuster/feroxbuster-2.13.1.toml
+++ b/packages/feroxbuster/feroxbuster-2.13.1.toml
@@ -2,19 +2,19 @@ version = "2.13.1"
 
 [url]
 x86_64-linux  = "https://github.com/epi052/feroxbuster/releases/download/v2.13.1/x86_64-linux-feroxbuster.tar.gz"
-aarch64-linux = "https://github.com/epi052/feroxbuster/releases/download/v2.13.1/x86_64-linux-feroxbuster.tar.gz"
+aarch64-linux = "https://github.com/epi052/feroxbuster/releases/download/v2.13.1/aarch64-linux-feroxbuster.zip"
 
 [blake3]
+aarch64-linux = "3f9a03faad03a926065169ccd0e4e06d04272e6c58dc2777eae683d3aebaa655"
 x86_64-linux  = "dfe5f8e03aa1244e50f36a074c1bf2417142bdc5f15a8d93e75b887330d37cb9"
-aarch64-linux = "dfe5f8e03aa1244e50f36a074c1bf2417142bdc5f15a8d93e75b887330d37cb9"
 
 [sha256]
+aarch64-linux = "1e5244e1f52e55a647b65e0c76ae7afe0b9983c1fbea30ed7c67e477175eb381"
 x86_64-linux  = "7985c00e6803b0f25d5e9139f7472279f3f4d891429627a5cedc629e53992d80"
-aarch64-linux = "7985c00e6803b0f25d5e9139f7472279f3f4d891429627a5cedc629e53992d80"
 
 [size]
+aarch64-linux = 5461708
 x86_64-linux  = 5012610
-aarch64-linux = 5012610
 
 [[extra]]
 url    = "https://raw.githubusercontent.com/epi052/feroxbuster/main/LICENSE"

--- a/packages/feroxbuster/pkg.toml
+++ b/packages/feroxbuster/pkg.toml
@@ -17,8 +17,13 @@ strategy     = "github-releases"
 repo         = "epi052/feroxbuster"
 strip-prefix = "v"
 
+# Upstream names each architecture differently and ships them in
+# different container formats, so neither can come from one template.
+[source.url]
+x86_64-linux  = "https://github.com/epi052/feroxbuster/releases/download/v${version}/x86_64-linux-feroxbuster.tar.gz"
+aarch64-linux = "https://github.com/epi052/feroxbuster/releases/download/v${version}/aarch64-linux-feroxbuster.zip"
+
 [source]
-url     = "https://github.com/epi052/feroxbuster/releases/download/v${version}/x86_64-linux-feroxbuster.tar.gz"
 
 [source.install]
 "feroxbuster" = "feroxbuster"


### PR DESCRIPTION
Two changes: one package was serving an x86_64 binary to aarch64, and the CI link check was reporting failures nobody could act on.

## feroxbuster handed aarch64 the x86_64 artifact

Its `[source]` hardcoded the architecture instead of templating it:

```
url = ".../v${version}/x86_64-linux-feroxbuster.tar.gz"
```

so both hosts resolved to the same file, with the same hash and size. Upstream ships the two architectures in different container formats, `x86_64-linux-feroxbuster.tar.gz` against `aarch64-linux-feroxbuster.zip`, so no single template covers them. It now uses a per-host `[source.url]` table, re-resolved to distinct URLs, hashes and sizes.

This was the only real instance. broot also pins one URL for both hosts, but that is correct: it ships a single multi-arch zip and selects with `${arch}` in its install map. A validate check distinguishing the two cases is in pkgforge/sbuilder#14.

## The URL check only looks at pinned artifacts now

It was checking every URL in every `.toml`, which meant project homepages as well as artifacts. Those are a long tail of sites behind Cloudflare that refuse CI runners outright:

```
Warning: https://ioquake3.org/ returned HTTP 403 (not checked)
```

`ioquake3.org` answers 200 from a normal machine on every method and user-agent I tried. The runner's IP is what is blocked, so no header fixes it, and a warning nobody can act on is worse than no check.

Pinned artifacts live on forges that answer reliably: 978 of them across github.com, raw.githubusercontent.com and a few GitLab instances. A broken one breaks installs, which is what the gate should be protecting. 25 sampled pinned URLs all returned 200 on the first HEAD, no escalation needed.

Homepage rot is real, and a sweep of all 1155 literal URLs found nine dead ones, already fixed on `main`. That is worth doing periodically, where noise costs nothing, rather than blocking every PR.
