### PR TITLE
feat: add iriunwebcam 2.9.3 (Anylinux AppImage, CI-built)

### DIFF
--- a/packages/iriunwebcam/iriunwebcam-2.9.3.toml
+++ b/packages/iriunwebcam/iriunwebcam-2.9.3.toml
@@ -1,14 +1,14 @@
 version = "2.9.3"
-date    = "2026-08-21T03:26:18Z"
+date    = "2026-08-29T04:14:41Z"
 
 [url]
-x86_64-linux = "https://github.com/sharno/IriunWebcam-AppImage/releases/download/v2.9.3/IriunWebcam-2.9.3-x86_64.AppImage"
+x86_64-linux = "https://github.com/sharno/IriunWebcam-AppImage/releases/download/2.9.3%402026-08-29_1787976881/IriunWebcam-2.9.3-anylinux-x86_64.AppImage"
 
 [blake3]
-x86_64-linux = "ee4247aca737714a7b7d6652ae4c1cba31f501093a058c047195615c3b309bf9"
+x86_64-linux = "7e5dfe5b5c80a6f58ac3472f690ef47c9c8d072e219e75e2d10583f2f0e8e930"
 
 [sha256]
-x86_64-linux = "8a8df13e7c1ef11bc1c8f4c842b786ff6e5bb47fda46b0b30f3e15ec048d73e9"
+x86_64-linux = "27de32352d782cada92adccddb5f54861d074eff4de1e34336becad9a0b37ed7"
 
 [size]
-x86_64-linux = 40098296
+x86_64-linux = 34687557

--- a/packages/iriunwebcam/iriunwebcam-2.9.3.toml
+++ b/packages/iriunwebcam/iriunwebcam-2.9.3.toml
@@ -1,0 +1,13 @@
+version = "2.9.3"
+
+[url]
+x86_64-linux = "https://iriun.gitlab.io/iriunwebcam-2.9.3.deb"
+
+[blake3]
+x86_64-linux = "1b657126ffab76b7e431e809873b8143de0b38db2296d2187afbc1d751fa8faf"
+
+[sha256]
+x86_64-linux = "3635363ec642788aca1e5a3fd45ee978ab6f69ac0a0d2ab5d68ae11bc4a80cc9"
+
+[size]
+x86_64-linux = 1071154

--- a/packages/iriunwebcam/iriunwebcam-2.9.3.toml
+++ b/packages/iriunwebcam/iriunwebcam-2.9.3.toml
@@ -5,10 +5,10 @@ date    = "2026-08-21T03:26:18Z"
 x86_64-linux = "https://github.com/sharno/IriunWebcam-AppImage/releases/download/v2.9.3/IriunWebcam-2.9.3-x86_64.AppImage"
 
 [blake3]
-x86_64-linux = "02c00af86fdbe7af86b4e79fc86b88916cb76c648ab4df890522cfaa07dc3c3c"
+x86_64-linux = "ee4247aca737714a7b7d6652ae4c1cba31f501093a058c047195615c3b309bf9"
 
 [sha256]
-x86_64-linux = "018a1cade298de59607d3b5998f7be154ed47575f3f1b1d21e58302f223bc7e8"
+x86_64-linux = "8a8df13e7c1ef11bc1c8f4c842b786ff6e5bb47fda46b0b30f3e15ec048d73e9"
 
 [size]
-x86_64-linux = 2058744
+x86_64-linux = 40098296

--- a/packages/iriunwebcam/iriunwebcam-2.9.3.toml
+++ b/packages/iriunwebcam/iriunwebcam-2.9.3.toml
@@ -1,13 +1,14 @@
 version = "2.9.3"
+date    = "2026-08-21T03:26:18Z"
 
 [url]
-x86_64-linux = "https://iriun.gitlab.io/iriunwebcam-2.9.3.deb"
+x86_64-linux = "https://github.com/sharno/IriunWebcam-AppImage/releases/download/v2.9.3/IriunWebcam-2.9.3-x86_64.AppImage"
 
 [blake3]
-x86_64-linux = "1b657126ffab76b7e431e809873b8143de0b38db2296d2187afbc1d751fa8faf"
+x86_64-linux = "02c00af86fdbe7af86b4e79fc86b88916cb76c648ab4df890522cfaa07dc3c3c"
 
 [sha256]
-x86_64-linux = "3635363ec642788aca1e5a3fd45ee978ab6f69ac0a0d2ab5d68ae11bc4a80cc9"
+x86_64-linux = "018a1cade298de59607d3b5998f7be154ed47575f3f1b1d21e58302f223bc7e8"
 
 [size]
-x86_64-linux = 1071154
+x86_64-linux = 2058744

--- a/packages/iriunwebcam/pkg.toml
+++ b/packages/iriunwebcam/pkg.toml
@@ -18,9 +18,9 @@ portable-reason = "requires v4l2loopback kernel module and system PipeWire integ
 supported = ["x86_64-linux"]
 
 [update]
-strategy     = "github-releases"
-repo         = "sharno/IriunWebcam-AppImage"
-strip-prefix = "v"
+strategy   = "github-releases"
+repo       = "sharno/IriunWebcam-AppImage"
+tag-suffix = "strip"
 
 [source]
 github = "sharno/IriunWebcam-AppImage"

--- a/packages/iriunwebcam/pkg.toml
+++ b/packages/iriunwebcam/pkg.toml
@@ -1,6 +1,6 @@
 [pkg]
 name        = "iriunwebcam"
-type        = "static"
+type        = "appimage"
 description = "Use your phone's camera as a wireless webcam in your PC or Mac"
 homepage    = ["https://iriun.gitlab.io", "https://iriun.com"]
 license     = ["Proprietary"]
@@ -10,7 +10,6 @@ repology    = ["iriunwebcam"]
 note        = [
   "Proprietary software - Terms: https://iriun.com",
   "Requires v4l2loopback kernel module (v4l2loopback-dkms) and PipeWire",
-  "Depends: v4l2loopback-dkms, libqt6widgets6, qt6-qpa-plugins, adb (recommended)",
 ]
 portable = true
 portable-reason = "requires v4l2loopback kernel module and system PipeWire integration"
@@ -19,16 +18,10 @@ portable-reason = "requires v4l2loopback kernel module and system PipeWire integ
 supported = ["x86_64-linux"]
 
 [update]
-strategy = "html-regex"
-repo     = "https://iriun.gitlab.io/"
-pattern  = "iriunwebcam-(\\d+\\.\\d+\\.\\d+)\\.deb"
+strategy     = "github-releases"
+repo         = "sharno/IriunWebcam-AppImage"
+strip-prefix = "v"
 
 [source]
-url = "https://iriun.gitlab.io/iriunwebcam-${version}.deb"
-
-[source.install]
-"usr/local/bin/iriunwebcam"                                   = "bin/iriunwebcam"
-"usr/lib/x86_64-linux-gnu/spa-0.2/iriunaudio/libspa-iriunaudio.so" = "lib/spa-0.2/iriunaudio/libspa-iriunaudio.so"
-"usr/share/applications/iriunwebcam.desktop"                  = "share/applications/iriunwebcam.desktop"
-"usr/share/pixmaps/iriunwebcam.png"                           = "share/pixmaps/iriunwebcam.png"
-"usr/share/pipewire/pipewire.conf.d/iriunaudio.conf"          = "share/pipewire/pipewire.conf.d/iriunaudio.conf"
+github = "sharno/IriunWebcam-AppImage"
+glob   = "*${arch}*.AppImage"

--- a/packages/iriunwebcam/pkg.toml
+++ b/packages/iriunwebcam/pkg.toml
@@ -1,0 +1,34 @@
+[pkg]
+name        = "iriunwebcam"
+type        = "static"
+description = "Use your phone's camera as a wireless webcam in your PC or Mac"
+homepage    = ["https://iriun.gitlab.io", "https://iriun.com"]
+license     = ["Proprietary"]
+maintainer  = ["Mohamed Elsharnouby <sharnoby3@gmail.com>"]
+category    = ["AudioVideo", "Video", "Utility"]
+repology    = ["iriunwebcam"]
+note        = [
+  "Proprietary software - Terms: https://iriun.com",
+  "Requires v4l2loopback kernel module (v4l2loopback-dkms) and PipeWire",
+  "Depends: v4l2loopback-dkms, libqt6widgets6, qt6-qpa-plugins, adb (recommended)",
+]
+portable = true
+portable-reason = "requires v4l2loopback kernel module and system PipeWire integration"
+
+[host]
+supported = ["x86_64-linux"]
+
+[update]
+strategy = "html-regex"
+repo     = "https://iriun.gitlab.io/"
+pattern  = "iriunwebcam-(\\d+\\.\\d+\\.\\d+)\\.deb"
+
+[source]
+url = "https://iriun.gitlab.io/iriunwebcam-${version}.deb"
+
+[source.install]
+"usr/local/bin/iriunwebcam"                                   = "bin/iriunwebcam"
+"usr/lib/x86_64-linux-gnu/spa-0.2/iriunaudio/libspa-iriunaudio.so" = "lib/spa-0.2/iriunaudio/libspa-iriunaudio.so"
+"usr/share/applications/iriunwebcam.desktop"                  = "share/applications/iriunwebcam.desktop"
+"usr/share/pixmaps/iriunwebcam.png"                           = "share/pixmaps/iriunwebcam.png"
+"usr/share/pipewire/pipewire.conf.d/iriunaudio.conf"          = "share/pipewire/pipewire.conf.d/iriunaudio.conf"


### PR DESCRIPTION
Adds `iriunwebcam` (Iriun Webcam 2.9.3, proprietary) as an AppImage package, like `discord` / `slack`.

### AppImage source

The artifact is built by CI in [sharno/IriunWebcam-AppImage](https://github.com/sharno/IriunWebcam-AppImage) using the [Anylinux-AppImages](https://github.com/pkgforge-dev/Anylinux-AppImages) template ([commit 7ab4309](https://github.com/sharno/IriunWebcam-AppImage/commit/7ab4309)):

- builds in the `ghcr.io/pkgforge-dev/archlinux` container via `anylinux-setup-action` → result does not depend on the packager's machine
- `make-appimage.sh` detects the version from https://iriun.gitlab.io, pulls the upstream deb, deploys with `quick-sharun` (Qt6 + plugins and all transitive libs auto-deployed; `iriunaudio` SPA plugin and `pipewire.conf.d` shipped as data)
- released via `make-stable-appimage-release`; rebuilds on a 21-day cron, so bumps don't require manual packaging
- result: `IriunWebcam-2.9.3-anylinux-x86_64.AppImage` (DWARFS, sharun + uruntime, no host Qt needed)

The previously hand-built AppImage and the one committed to the repo were removed; the release only exists as a CI artifact.

### Pinned version (`iriunwebcam-2.9.3.toml`)

```
version = "2.9.3"
date    = "2026-08-29T04:14:41Z"

[url]
x86_64-linux = "https://github.com/sharno/IriunWebcam-AppImage/releases/download/2.9.3%402026-08-29_1787976881/IriunWebcam-2.9.3-anylinux-x86_64.AppImage"

[blake3]
x86_64-linux = "7e5dfe5b5c80a6f58ac3472f690ef47c9c8d072e219e75e2d10583f2f0e8e930"

[sha256]
x86_64-linux = "27de32352d782cada92adccddb5f54861d074eff4de1e34336becad9a0b37ed7"

[size]
x86_64-linux = 34687557
```

`pkg.toml` uses `tag-suffix = "strip"` for the `VERSION@DATE` tag format, same as `discord`.

### Validation

- `sbuild validate` → 0 errors, 0 warnings across the tree (1309 artifacts / 534 packages)
- `sbuild audit` → AppImages have no install map, so they are skipped (same as `discord`)
- CI artifact verified: extracted with `APPIMAGE_EXTRACT_AND_RUN=1`, binary runs (offscreen), bundled Qt plugins load, `spa-0.2/iriunaudio/libspa-iriunaudio.so` has no missing deps, `share/pipewire/pipewire.conf.d/iriunaudio.conf` present

### Host requirements

`portable = true` — the v4l2loopback kernel module (`v4l2loopback-dkms`, cannot be bundled) and a running PipeWire user service are host deps.
