### PR TITLE
mate-calculator: init

### DIFF
--- a/packages/mate-calculator/mate-calculator-1.28.0-3.toml
+++ b/packages/mate-calculator/mate-calculator-1.28.0-3.toml
@@ -1,0 +1,22 @@
+version = "1.28.0-3"
+date    = "2026-07-14T23:27:41Z"
+
+[url]
+x86_64-linux  = "https://github.com/pkgforge-dev/MATE-Calculator-AppImage/releases/download/1.28.0-3%402026-07-14_1784071660/MATE_Calculator-1.28.0-3-anylinux-x86_64.AppImage"
+aarch64-linux = "https://github.com/pkgforge-dev/MATE-Calculator-AppImage/releases/download/1.28.0-3%402026-07-14_1784071660/MATE_Calculator-1.28.0-3-anylinux-aarch64.AppImage"
+
+[blake3]
+x86_64-linux  = "1e8d98aec6bfa056f997600ca088a5a287d6b53d1865c9b383fbcad779abdb59"
+aarch64-linux = "c2448e7aa6a50519a53348393219ab628311343f1d03310e21ca925fc574536a"
+
+[sha256]
+x86_64-linux  = "2b5ecdaacca37b8c3aa239a45861cf325ac2b26294959d2b33e2986e0f4ada4a"
+aarch64-linux = "e95a0e2ca9504f56baf6016b1062438a6e5d808b2ad379acb8a9e6c5ad5f909e"
+
+[size]
+x86_64-linux  = 18754126
+aarch64-linux = 18698379
+
+[[extra]]
+url    = "https://raw.githubusercontent.com/mate-desktop/mate-calc/refs/heads/master/COPYING"
+to     = "LICENSE"

--- a/packages/mate-calculator/pkg.toml
+++ b/packages/mate-calculator/pkg.toml
@@ -1,0 +1,29 @@
+[pkg]
+name        = "mate-calculator"
+type        = "appimage"
+description = "Calculator for MATE"
+homepage    = [
+  "https://mate-desktop.org",
+  "https://github.com/pkgforge-dev/MATE-Calculator-AppImage",
+]
+license    = ["GPL-2.0"]
+maintainer = ["QaidVoid (contact@qaidvoid.dev)"]
+category   = ["Calculator", "Utility"]
+repology   = ["mate-calc"]
+
+[host]
+supported = ["x86_64-linux", "aarch64-linux"]
+
+[update]
+strategy   = "github-releases"
+repo       = "pkgforge-dev/MATE-Calculator-AppImage"
+tag-suffix = "strip"
+
+[source]
+github = "pkgforge-dev/MATE-Calculator-AppImage"
+glob   = "*${arch}*.appimage"
+
+[[extra]]
+url = "https://raw.githubusercontent.com/mate-desktop/mate-calc/refs/heads/master/COPYING"
+to  = "LICENSE"
+verify = false


### PR DESCRIPTION
Redo of #950, which was written for the old SBUILD YAML format and left `category`, `tag` and the licence URL as `TODO`.

Modelled on `gnome-calculator`, same upstream org and same AppImage pipeline, so `tag-suffix = "strip"` handles the `1.28.0-3@2026-07-14_...` tag shape.

Two corrections to what #950 had:

- `repology` is `mate-calc`. `mate-calculator` is not a repology project.
- `license` is GPL-2.0 from `mate-desktop/mate-calc`. The MIT on the AppImage repo covers the packaging, not the application.

`sbuild resolve` pins 1.28.0-3 for x86_64 and aarch64, `hashfill` filled both, `sbuild validate` reports 0 errors.

Note the binary is `mate-calc`; upstream installs `mate-calculator` as a symlink to it. Named the package `mate-calculator` to sit alongside `gnome-calculator`, happy to switch if you would rather match the executable.
