### PR TITLE
feishin: init

### DIFF
--- a/packages/feishin/feishin-1.15.1.toml
+++ b/packages/feishin/feishin-1.15.1.toml
@@ -2,13 +2,17 @@ version = "1.15.1"
 date    = "2026-07-19T23:54:40Z"
 
 [url]
-x86_64-linux = "https://github.com/jeffvli/feishin/releases/download/v1.15.1/Feishin-linux-x86_64.AppImage"
+x86_64-linux  = "https://github.com/jeffvli/feishin/releases/download/v1.15.1/Feishin-linux-x86_64.AppImage"
+aarch64-linux = "https://github.com/jeffvli/feishin/releases/download/v1.15.1/Feishin-linux-arm64.AppImage"
 
 [blake3]
-x86_64-linux = "2a5f470bb0902aa883fc8a5cab652e330f7899045d6e19316b02d85e59f09b54"
+x86_64-linux  = "2a5f470bb0902aa883fc8a5cab652e330f7899045d6e19316b02d85e59f09b54"
+aarch64-linux = "9fdf3c47a775fb9b6f47395bdc751650f120313804ecac109952383634c59c97"
 
 [sha256]
-x86_64-linux = "5d04e917aa39d13f3089452d1a5f30a61fde80a804ab00d49b7a250ce4b96515"
+x86_64-linux  = "5d04e917aa39d13f3089452d1a5f30a61fde80a804ab00d49b7a250ce4b96515"
+aarch64-linux = "8d1372c1d7f4eb764bbd6b93887dd47fe1f6f206535b047b4e1e6bda1ca17025"
 
 [size]
-x86_64-linux = 200067927
+x86_64-linux  = 200067927
+aarch64-linux = 199422043

--- a/packages/feishin/feishin-1.15.1.toml
+++ b/packages/feishin/feishin-1.15.1.toml
@@ -1,0 +1,14 @@
+version = "1.15.1"
+date    = "2026-07-19T23:54:40Z"
+
+[url]
+x86_64-linux = "https://github.com/jeffvli/feishin/releases/download/v1.15.1/Feishin-linux-x86_64.AppImage"
+
+[blake3]
+x86_64-linux = "2a5f470bb0902aa883fc8a5cab652e330f7899045d6e19316b02d85e59f09b54"
+
+[sha256]
+x86_64-linux = "5d04e917aa39d13f3089452d1a5f30a61fde80a804ab00d49b7a250ce4b96515"
+
+[size]
+x86_64-linux = 200067927

--- a/packages/feishin/pkg.toml
+++ b/packages/feishin/pkg.toml
@@ -9,7 +9,11 @@ category    = ["AudioVideo", "Audio"]
 repology    = ["feishin"]
 
 [host]
-supported = ["x86_64-linux"]
+supported = ["x86_64-linux", "aarch64-linux"]
+
+[arch]
+x86_64  = "x86_64"
+aarch64 = "arm64"
 
 [update]
 strategy     = "github-releases"
@@ -18,4 +22,4 @@ strip-prefix = "v"
 
 [source]
 github = "jeffvli/feishin"
-glob   = "Feishin-linux-x86_64.AppImage"
+glob   = "Feishin-linux-${arch}.AppImage"

--- a/packages/feishin/pkg.toml
+++ b/packages/feishin/pkg.toml
@@ -1,0 +1,21 @@
+[pkg]
+name        = "feishin"
+type        = "appimage"
+description = "A modern self-hosted music player frontend"
+homepage    = ["https://github.com/jeffvli/feishin"]
+license     = ["GPL-3.0"]
+maintainer  = ["imshinyu (imshinyu@proton.me)"]
+category    = ["AudioVideo", "Audio"]
+repology    = ["feishin"]
+
+[host]
+supported = ["x86_64-linux"]
+
+[update]
+strategy     = "github-releases"
+repo         = "jeffvli/feishin"
+strip-prefix = "v"
+
+[source]
+github = "jeffvli/feishin"
+glob   = "Feishin-linux-x86_64.AppImage"


### PR DESCRIPTION
its a music player frontend that supports
> any music server that implements a [Navidrome](https://www.navidrome.org/), [Jellyfin](https://jellyfin.org/), or [OpenSubsonic compatible](https://opensubsonic.netlify.app/) API.

their releases dont include the version in the `.AppImage` name unlike `.exe` so i didnt know what to put inside `glob`